### PR TITLE
Double Buffering

### DIFF
--- a/script/min.lua
+++ b/script/min.lua
@@ -1,4 +1,6 @@
 local gif = dofile("host:script/gif.lua")
+local VRAM = require("vram")
+local D2D = require("draw2d")
 
 local gs = nil
 
@@ -10,21 +12,20 @@ function writeToBuffer(b, ints)
 end
 
 function PS2PROG.start()
-  DMA.init(DMA.GIF)
-  gs = GS.newState(640, 448, GS.INTERLACED, GS.NTSC)
-  local fb = gs:alloc(640, 448, GS.PSM24)
-  local zb = gs:alloc(640, 448, GS.PSMZ24)
-  gs:setBuffers(fb, zb)
-  gs:clearColour(0, 255, 0)
+  dma.init(dma.gif)
+  gs.setoutput(640, 448, gs.interlaced, gs.ntsc)
+  local fb1 = vram.buffer(640, 448, gs.psm24, 256)
+  local fb2 = vram.buffer(640, 448, gs.psm24, 256)
+  local zb = vram.buffer(640, 448, gs.psmz24, 256)
+  gs.setbuffers(fb1, fb2, zb)
+  d2d:clearcolour(0x2b, 0x2b, 0x2b)
+
+
 end
 
 function PS2PROG.frame()
-  local db = RM.getDrawBuffer(5000)
-  db:frameStart(gs)
-  -- writeToBuffer(db, {0x8001, 0x10000000, 0xe, 0x0, 0x1, 0x0, 0x61, 0x0})
-  db:frameEnd(gs)
-  DMA.send(db, DMA.GIF)
-  db:free()
+  D2D:frameStart(gs)
+  D2D:frameEnd(gs)
 end
 
 

--- a/script/rect.lua
+++ b/script/rect.lua
@@ -2,31 +2,28 @@
 local GIF = require("gif")
 local P = require("ps2const")
 local D2D = require("draw2d")
+local VRAM = require("vram")
 
 local gs = nil
 
 function PS2PROG.start()
   DMA.init(DMA.GIF)
-  gs = GS.newState(640, 448, GS.INTERLACED, GS.NTSC)
-  local fb = gs:alloc(640, 448, GS.PSM24)
-  local zb = gs:alloc(640, 448, GS.PSMZ24)
-  gs:setBuffers(fb, zb)
-  gs:clearColour(0x2b, 0x2b, 0x2b)
+  gs = GS.setOutput(640, 448, GS.INTERLACED, GS.NTSC)
+  local fb1 = VRAM.buffer(640, 448, GS.PSM24, 256)
+  local fb2 = VRAM.buffer(640, 448, GS.PSM24, 256)
+  local zb = VRAM.buffer(640, 448, GS.PSMZ24, 256)
+  GS.setBuffers(fb1, fb2, zb)
+  D2D:clearColour(0x2b, 0x2b, 0x2b)
+
 end
 
 function PS2PROG.frame()
-  D2D:newBuffer()
-  local db = D2D:getBuffer()
-  db:frameStart(gs)
+  D2D:frameStart(gs)
   D2D:setColour(255,0,0,0x80)
   D2D:rect(-200, -200, 200, 200)
-  db = D2D:getBuffer()
-  db:frameEnd(gs)
+  D2D:frameEnd(gs)
   D2D:kick()
-  print("tris/frame = " .. D2D.rawtri .. ", KC=" .. D2D.kc)
-  D2D.rawtri = 0
-  D2D.kc = 0
-  --db:free()
+  print("tris/frame = " .. D2D.prev.rawtri .. ", KC=" .. D2D.prev.kc)
 end
 
 

--- a/script/texture.lua
+++ b/script/texture.lua
@@ -88,30 +88,23 @@ function PS2PROG.start()
   testTex = loadTexture("host:test.tga", 64, 64)
   fnt = loadTexture("host:bigfont.tga", 256, 64)
   DMA.init(DMA.GIF)
-  gs = GS.newState(640, 448, GS.INTERLACED, GS.NTSC)
-  local fb = VRAM.buffer(640, 440, GS.PSM24, 256)
-  local zb = VRAM.buffer(640, 440, GS.PSMZ24, 256)
-  print("setting new buffers")
-  gs:setBuffers(fb, zb)
-  gs:clearColour(0x2b, 0x2b, 0x2b)
-
+  gs = GS.setOutput(640, 448, GS.INTERLACED, GS.NTSC)
+  local fb1 = VRAM.buffer(640, 448, GS.PSM24, 256)
+  local fb2 = VRAM.buffer(640, 448, GS.PSM24, 256)
+  local zb = VRAM.buffer(640, 448, GS.PSMZ24, 256)
+  GS.setBuffers(fb1, fb2, zb)
+  D2D:clearColour(0x2b, 0x2b, 0x2b)
 end
 
 xx = -200
 local dt = 1/60
 function PS2PROG.frame()
-  D2D:newBuffer()
-  local db = D2D:getBuffer()
-  db:frameStart(gs)
+  D2D:frameStart(gs)
   D2D:setColour(0x80,0x80,0x80,0x80)
   D2D:sprite(testTex, xx, -200, 200, 200, 0, 0, 1, 1)
   D2D:sprite(fnt, 50, 100, 256, 64, 0, 0, 1, 1)
-  db = D2D:getBuffer()
-  db:frameEnd(gs)
-  D2D:kick()
-  print("tris/frame = " .. D2D.rawtri .. ", KC=" .. D2D.kc)
-  D2D.rawtri = 0
-  D2D.kc = 0
+  D2D:frameEnd(gs)
+  print("tris/frame = " .. D2D.prev.rawtri .. ", KC=" .. D2D.prev.kc)
 
   if PAD.held(PAD.LEFT) then xx = xx - 50*dt end
   if PAD.held(PAD.RIGHT) then xx = xx + 50*dt end

--- a/script/vram.lua
+++ b/script/vram.lua
@@ -1,6 +1,8 @@
 
 local vram = {}
 local basePtr = 0
+-- maximum is 4mb
+local max = math.floor(4 * 1024 * 1024)
 
 function vpa(v, a)
   return v + a - (v%a)
@@ -9,16 +11,20 @@ end
 function vram.alloc(b, align)
   local out = basePtr
   out = out + align - (out%align)
+  if out + b >= max then
+    print("vram overflow: " .. out .. " + " .. b .. " > 4MB")
+    error("VRAM overflow")
+  end
   basePtr = out + b
   print("vram alloc: " .. out .. " base -> " .. basePtr)
   return out
 end
 
 function vram.size(w, h, psm, align)
-  if w%align ~= 0 then
-    w = vpa(w, 64) 
-  end
-  local size = w*h*4
+--  if w%align ~= 0 then
+--    w = vpa(w, 64) 
+--  end
+  local size = w*h
   if psm == GS.PSM16 or psm == GS.PSM16S or psm == GS.PSMZ16 or psm == GS.PSMZ16S then
     math.floor(width*height*0.5)
   elseif psm == GS.PSM8 then size = math.floor(width*height*2^-2)

--- a/src/bufferlua.c
+++ b/src/bufferlua.c
@@ -3,6 +3,8 @@
 
 #include <draw.h>
 #include <tamtypes.h>
+#include <gs_gp.h>
+#include <gs_psm.h>
 
 #include <stdlib.h>
 #include <string.h>
@@ -231,42 +233,36 @@ int drawlua_init(lua_State *l) {
   return 0;
 }
 
+zbuffer_t zb = {0};
 static int drawlua_start_frame(lua_State *l) {
   // drawbuffer is arg #1
   lua_pushstring(l, "head");
   lua_gettable(l, 1);
   int head = lua_tointeger(l, -1);
-  /*
-  lua_pushstring(l, "size");
-  lua_gettable(l, 1);
-  int size = lua_tointeger(l, -1);
-  */
+
   lua_pushstring(l, "ptr");
   lua_gettable(l, 1);
   char *ptr = (char *)lua_touserdata(l, -1);
 
-  // gs is arg #2
-  lua_pushstring(l, "state");
-  lua_gettable(l, 2);
-  struct gs_state *st = (struct gs_state *)lua_touserdata(l, -1);
-  lua_pushstring(l, "width");
-  lua_gettable(l, 2);
-  int width = lua_tointeger(l, -1);
-  lua_pushstring(l, "height");
-  lua_gettable(l, 2);
-  int height = lua_tointeger(l, -1);
+  int width = lua_tointeger(l, 2);
+  int height = lua_tointeger(l, 3);
+  int r = lua_tointeger(l, 4);
+  int g = lua_tointeger(l, 5);
+  int b = lua_tointeger(l, 6);
 
-  float halfw = st->fb.width / 2.f;
-  float halfh = st->fb.height / 2.f;
-
-  // info("clear screen :: (%d, %d, %d)", st->clear_r, st->clear_g,
-  // st->clear_b);
+  float halfw = width / 2.f;
+  float halfh = height / 2.f;
 
   qword_t *q = (qword_t *)(ptr + head);
-  q = draw_disable_tests(q, 0, &st->zb);
+  q = draw_disable_tests(q, 0, &zb);
+  PACK_GIFTAG(q,GIF_SET_TAG(1,0,0,0,GIF_FLG_PACKED,1), GIF_REG_AD);
+  q++;
+  PACK_GIFTAG(q, GS_SET_TEST(DRAW_ENABLE,ATEST_METHOD_NOTEQUAL,0x00,ATEST_KEEP_FRAMEBUFFER,
+    DRAW_DISABLE,DRAW_DISABLE,
+    DRAW_ENABLE,ZTEST_METHOD_ALLPASS), GS_REG_TEST);
+  q++;
   q = draw_clear(q, 0, 2048.0f - halfw, 2048.0f - halfh, width, height,
-                 st->clear_r, st->clear_g, st->clear_b);
-  // q = draw_enable_tests(q, 0, &st->zb);
+                 r, g, b);
 
   head = (char *)q - ptr;
   // info("db head -> %d", head);

--- a/src/bufferlua.c
+++ b/src/bufferlua.c
@@ -2,9 +2,9 @@
 #include <lua.h>
 
 #include <draw.h>
-#include <tamtypes.h>
 #include <gs_gp.h>
 #include <gs_psm.h>
+#include <tamtypes.h>
 
 #include <stdlib.h>
 #include <string.h>
@@ -255,14 +255,16 @@ static int drawlua_start_frame(lua_State *l) {
 
   qword_t *q = (qword_t *)(ptr + head);
   q = draw_disable_tests(q, 0, &zb);
-  PACK_GIFTAG(q,GIF_SET_TAG(1,0,0,0,GIF_FLG_PACKED,1), GIF_REG_AD);
+  PACK_GIFTAG(q, GIF_SET_TAG(1, 0, 0, 0, GIF_FLG_PACKED, 1), GIF_REG_AD);
   q++;
-  PACK_GIFTAG(q, GS_SET_TEST(DRAW_ENABLE,ATEST_METHOD_NOTEQUAL,0x00,ATEST_KEEP_FRAMEBUFFER,
-    DRAW_DISABLE,DRAW_DISABLE,
-    DRAW_ENABLE,ZTEST_METHOD_ALLPASS), GS_REG_TEST);
+  PACK_GIFTAG(q,
+              GS_SET_TEST(DRAW_ENABLE, ATEST_METHOD_NOTEQUAL, 0x00,
+                          ATEST_KEEP_FRAMEBUFFER, DRAW_DISABLE, DRAW_DISABLE,
+                          DRAW_ENABLE, ZTEST_METHOD_ALLPASS),
+              GS_REG_TEST);
   q++;
-  q = draw_clear(q, 0, 2048.0f - halfw, 2048.0f - halfh, width, height,
-                 r, g, b);
+  q = draw_clear(q, 0, 2048.0f - halfw, 2048.0f - halfh, width, height, r, g,
+                 b);
 
   head = (char *)q - ptr;
   // info("db head -> %d", head);

--- a/src/gs.h
+++ b/src/gs.h
@@ -2,7 +2,6 @@
 #ifndef GS_H
 #define GS_H
 
-
 int gs_init();
 int gs_flip();
 

--- a/src/gs.h
+++ b/src/gs.h
@@ -1,0 +1,9 @@
+
+#ifndef GS_H
+#define GS_H
+
+
+int gs_init();
+int gs_flip();
+
+#endif

--- a/src/gslua.c
+++ b/src/gslua.c
@@ -6,9 +6,9 @@
 #include <gs_psm.h>
 #include <inttypes.h>
 
+#include <malloc.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 
 #include "log.h"
 #include "script.h"
@@ -25,13 +25,13 @@ static qword_t *flip_buffer;
 int gs_init() {
   info("init GS -- no framebuffer");
   st = calloc(1, sizeof(struct gs_state));
-  flip_buffer = memalign(64, 10*16);
+  flip_buffer = memalign(64, 10 * 16);
   return 0;
 }
 
 int gs_flip() {
   trace("GS FLIP START");
-  memset(flip_buffer, 0, 10*16);
+  memset(flip_buffer, 0, 10 * 16);
   framebuffer_t *fb = &st->fb[st->ctx];
   graph_set_framebuffer_filtered(fb->address, fb->width, fb->psm, 0, 0);
   st->ctx ^= 1;
@@ -85,7 +85,6 @@ static int gslua_set_buffers(lua_State *l) {
   lua_gettable(l, 3);
   int zb_fmt = lua_tointeger(l, -1);
   lua_pop(l, 1);
-
 
   st->fb[0].address = fb1_addr;
   st->fb[0].width = fb_width;

--- a/src/gslua.c
+++ b/src/gslua.c
@@ -8,69 +8,76 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <malloc.h>
 
 #include "log.h"
 #include "script.h"
 
-static int gslua_clear_col(lua_State *l) {
-  lua_pushstring(l, "state");
-  lua_gettable(l, 1);
-  struct gs_state *st = (struct gs_state *)lua_touserdata(l, -1);
-  lua_pop(l, 1);
-  if (!st) {
-    logerr("GS state was NULL");
-    return 0;
-  }
-  int r = lua_tointeger(l, 2);
-  int g = lua_tointeger(l, 3);
-  int b = lua_tointeger(l, 4);
-  st->clear_r = r;
-  st->clear_g = g;
-  st->clear_b = b;
+struct gs_state {
+  framebuffer_t fb[2];
+  zbuffer_t zb;
+  int ctx;
+};
+
+static struct gs_state *st;
+static qword_t *flip_buffer;
+
+int gs_init() {
+  info("init GS -- no framebuffer");
+  st = calloc(1, sizeof(struct gs_state));
+  flip_buffer = memalign(64, 10*16);
   return 0;
 }
 
-static int gslua_vram_alloc(lua_State *l) {
-  int width = lua_tointeger(l, 2);
-  int height = lua_tointeger(l, 3);
-  int format = lua_tointeger(l, 4);
-  int addr = graph_vram_allocate(width, height, format, GRAPH_ALIGN_PAGE);
-  lua_createtable(l, 0, 4);
-  lua_pushinteger(l, addr);
-  lua_setfield(l, -2, "address");
-  lua_pushinteger(l, width);
-  lua_setfield(l, -2, "width");
-  lua_pushinteger(l, height);
-  lua_setfield(l, -2, "height");
-  lua_pushinteger(l, format);
-  lua_setfield(l, -2, "format");
-  return 1;
+int gs_flip() {
+  trace("GS FLIP START");
+  memset(flip_buffer, 0, 10*16);
+  framebuffer_t *fb = &st->fb[st->ctx];
+  graph_set_framebuffer_filtered(fb->address, fb->width, fb->psm, 0, 0);
+  st->ctx ^= 1;
+  trace("GS BUILD FLIP BUFFER");
+  qword_t *q = flip_buffer;
+  q = draw_framebuffer(q, 0, &st->fb[st->ctx]);
+  q = draw_finish(q);
+  dma_wait_fast();
+  trace("GS SEND FLIP BUFFER");
+  dma_channel_send_normal(DMA_CHANNEL_GIF, flip_buffer, q - flip_buffer, 0, 0);
+  trace("GS WAIT FLIP BUFFER DRAW FINISH");
+  draw_wait_finish();
+  trace("GS FLIP DONE");
+  return 0;
 }
 
 static int gslua_set_buffers(lua_State *l) {
-  // get fields from SELF argument (#1)
-  lua_pushstring(l, "state");
-  lua_gettable(l, 1);
-  struct gs_state *st = (struct gs_state *)lua_touserdata(l, -1);
-  lua_pop(l, 1);
-  // get fields from FB argument (#2)
+  if (!st) {
+    lua_pushstring(l, "GS state was NULL");
+    lua_error(l);
+    return 1;
+  }
+
+  // get fields from FB argument (#1, #2)
   lua_pushstring(l, "width");
-  lua_gettable(l, 2);
+  lua_gettable(l, 1);
   int fb_width = lua_tointeger(l, -1);
   lua_pop(l, 1);
   lua_pushstring(l, "height");
-  lua_gettable(l, 2);
+  lua_gettable(l, 1);
   int fb_height = lua_tointeger(l, -1);
   lua_pop(l, 1);
   lua_pushstring(l, "address");
-  lua_gettable(l, 2);
-  int fb_addr = lua_tointeger(l, -1);
+  lua_gettable(l, 1);
+  int fb1_addr = lua_tointeger(l, -1);
   lua_pop(l, 1);
   lua_pushstring(l, "format");
-  lua_gettable(l, 2);
+  lua_gettable(l, 1);
   int fb_fmt = lua_tointeger(l, -1);
   lua_pop(l, 1);
-  // get fields from ZB argument (#3)
+  lua_pushstring(l, "address");
+  lua_gettable(l, 2);
+  int fb2_addr = lua_tointeger(l, -1);
+  lua_pop(l, 1);
+
+  // get fields from ZB argument (#4)
   lua_pushstring(l, "address");
   lua_gettable(l, 3);
   int zb_addr = lua_tointeger(l, -1);
@@ -79,30 +86,33 @@ static int gslua_set_buffers(lua_State *l) {
   int zb_fmt = lua_tointeger(l, -1);
   lua_pop(l, 1);
 
-  if (!st) {
-    // TODO(Tom Marks): error
-  }
 
-  st->fb.address = fb_addr;
-  st->fb.width = fb_width;
-  st->fb.height = fb_height;
-  st->fb.psm = fb_fmt;
-  st->fb.mask = 0;
+  st->fb[0].address = fb1_addr;
+  st->fb[0].width = fb_width;
+  st->fb[0].height = fb_height;
+  st->fb[0].psm = fb_fmt;
+  st->fb[0].mask = 0;
+  st->fb[1].address = fb2_addr;
+  st->fb[1].width = fb_width;
+  st->fb[1].height = fb_height;
+  st->fb[1].psm = fb_fmt;
+  st->fb[1].mask = 0;
+
   st->zb.address = zb_addr;
   st->zb.zsm = zb_fmt;
   // st->zb.method = ZTEST_METHOD_GREATER_EQUAL;
   st->zb.method = ZTEST_METHOD_ALLPASS;
   st->zb.mask = 0;
-  graph_set_framebuffer_filtered(st->fb.address, fb_width, fb_fmt, 0, 0);
+  graph_set_framebuffer_filtered(fb2_addr, fb_width, fb_fmt, 0, 0);
   graph_enable_output();
 
   // init draw state
   qword_t *head = malloc(20 * 16);
   memset(head, 0, 20 * 16);
   qword_t *q = head;
-  q = draw_setup_environment(q, 0, &st->fb, &st->zb);
-  q = draw_primitive_xyoffset(q, 0, 2048 - (st->fb.width / 2),
-                              2048 - (st->fb.height / 2));
+  q = draw_setup_environment(q, 0, st->fb, &st->zb);
+  q = draw_primitive_xyoffset(q, 0, 2048 - (fb_width / 2),
+                              2048 - (fb_height / 2));
   q = draw_finish(q);
   dma_channel_send_normal(DMA_CHANNEL_GIF, head, q - head, 0, 0);
   draw_wait_finish();
@@ -111,30 +121,12 @@ static int gslua_set_buffers(lua_State *l) {
   return 0;
 }
 
-static int gslua_new_state(lua_State *l) {
+static int gslua_set_output(lua_State *l) {
   int width = lua_tointeger(l, 1);
   int height = lua_tointeger(l, 2);
   int interlace = lua_tointeger(l, 3);
   int mode = lua_tointeger(l, 4);
-  // create table with GS state
-  lua_createtable(l, 0, 5);
-  lua_newuserdata(l, sizeof(struct gs_state));
-  lua_setfield(l, -2, "state");
-  lua_pushinteger(l, width);
-  lua_setfield(l, -2, "width");
-  lua_pushinteger(l, height);
-  lua_setfield(l, -2, "height");
-  lua_pushinteger(l, interlace);
-  lua_setfield(l, -2, "interlace");
-  lua_pushinteger(l, mode);
-  lua_setfield(l, -2, "mode");
 
-  lua_pushcfunction(l, gslua_vram_alloc);
-  lua_setfield(l, -2, "alloc");
-  lua_pushcfunction(l, gslua_set_buffers);
-  lua_setfield(l, -2, "setBuffers");
-  lua_pushcfunction(l, gslua_clear_col);
-  lua_setfield(l, -2, "clearColour");
   // initialize GS with no output
   graph_disable_output();
   graph_set_mode(interlace, mode, GRAPH_MODE_FIELD, GRAPH_DISABLE);
@@ -148,8 +140,10 @@ static int gslua_new_state(lua_State *l) {
   lua_setfield(l, -2, n)
 int gs_lua_init(lua_State *l) {
   lua_createtable(l, 0, 16);
-  lua_pushcfunction(l, gslua_new_state);
-  lua_setfield(l, -2, "newState");
+  lua_pushcfunction(l, gslua_set_output);
+  lua_setfield(l, -2, "setOutput");
+  lua_pushcfunction(l, gslua_set_buffers);
+  lua_setfield(l, -2, "setBuffers");
 
   bind("PSM4", GS_PSM_4);
   bind("PSM4HL", GS_PSM_4HL);

--- a/src/log.h
+++ b/src/log.h
@@ -10,7 +10,12 @@
 #define logmsg(lvl, msg, ...) ((void)0)
 #endif
 
+#ifdef LOG_TRACE
 #define trace(msg, ...) logmsg("[TRCE]", msg, ##__VA_ARGS__)
+#else
+#define trace(msg, ...) ((void)0)
+#endif
+
 #define info(msg, ...) logmsg("[INFO]", msg, ##__VA_ARGS__)
 #define logerr(msg, ...) logmsg("[ERRO]", msg, ##__VA_ARGS__)
 

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 
 #include "log.h"
 
+#include "gs.h"
 #include "pad.h"
 #include "script.h"
 
@@ -116,6 +117,8 @@ int main(int argc, char *argv[]) {
     startup = argv[1];
   }
 
+  gs_init();
+
   struct lua_State *L;
   L = luaL_newstate();
   if (!L) {
@@ -145,10 +148,14 @@ int main(int argc, char *argv[]) {
     dma_wait_fast();
     info("ON FRAME");
     ps2luaprog_onframe(L);
+    // may be required? -- dma_wait_fast();
     info("WAIT DRAW");
     draw_wait_finish();
     info("WAIT VSYNC");
     graph_wait_vsync();
+    info("FLIP");
+    gs_flip();
+    info("FLIPOUT");
   }
   info("main loop ended");
 }

--- a/src/script.h
+++ b/src/script.h
@@ -4,14 +4,6 @@
 
 #include <lua.h>
 
-struct gs_state {
-  framebuffer_t fb;
-  zbuffer_t zb;
-  unsigned char clear_r;
-  unsigned char clear_g;
-  unsigned char clear_b;
-};
-
 int gs_lua_init(lua_State *l);
 int dma_lua_init(lua_State *l);
 int drawlua_init(lua_State *l);


### PR DESCRIPTION
Resolves #10 

Framebuffers are now double-buffered. At the cost of more VRAM draw calls split over many buffers/DMA submits no longer flicker.

Existing tests (min.lua, stress.lua, texture.lua) are updated and functional.

rect.lua no longer runs, stalling after the first draw and never completing the "flip" of the framebuffers.