### PR TITLE
Improve path handling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,5 @@ jobs:
         with: 
           name: game package
           path: dist/
-        if: ${{ github.ref == 'refs/head/main' || startsWith(github.ref, 'refs/tags') }}
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,5 +21,6 @@ jobs:
         with: 
           name: game package
           path: dist/
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags') }}
 
 

--- a/script/ps2init.lua
+++ b/script/ps2init.lua
@@ -1,5 +1,5 @@
 
-local SEARCH_PATH = PS2_SCRIPT_PATH .. "?.lua"
+local SEARCH_PATH = PS2_SCRIPT_PATH .. "script/?.lua"
 
 dbgPrint("search path = " .. SEARCH_PATH)
 package.path = SEARCH_PATH

--- a/script/texture.lua
+++ b/script/texture.lua
@@ -21,72 +21,9 @@ local testTex = {}
 local fnt = nil
 
 
--- CURRENT TEXTURE LOADER CANNOT BE USED MID-FRAME!!!!!
-function loadTexture(fname, w, h)
-  print("LOAD TEX: " .. fname .. " @ PSM32")
-  local tt = {
-    basePtr = 0,
-    width = w,
-    height = h,
-    data = nil,
-    format = GS.PSM32
-  }
-
-  tt.data = TGA.load(fname, w, h)
-
-  -- only works for power of 2 textures @ psm32!!!!!
-  local texVramSize = w*h*4
-  tt.basePtr = VRAM.alloc(texVramSize, 256)
-  print("LOAD TEX: got texture VRAM addr = " .. tt.basePtr)
-
-  -- ib = RM.tmpBuffer(1000)
-  ib = RM.getDrawBuffer(5000)
-
-  GIF.tag(ib, GIF.PACKED, 4, false, {0xe})
-  GIF.bitBltBuf(ib, math.floor(tt.basePtr/64), math.floor(tt.width/64), tt.format)
-  GIF.trxPos(ib,0,0,0,0,0)
-  GIF.trxReg(ib,tt.width,tt.height)
-  GIF.trxDir(ib, 0)
-
-  -- ASSUMPTION about format!
-  local eeSize = tt.width*tt.height*4
-  local qwc = math.floor(eeSize / 16)
-  if qwc % 16 ~= 0 then qwc = qwc + 1 end
-  local blocksize = math.floor(4496/16)
-  local packets = math.floor(qwc / blocksize)
-  local remain = qwc % blocksize
-  print("LOAD TEX: transmitting in " .. packets .. " packets with " .. remain .. " left")
-
-  local tb = 0
-  while packets > 0 do
-    GIF.tag(ib, GIF.IMAGE, blocksize, false, {0}) 
-    print("LOAD TEX: copy from TT " .. tb*blocksize*16 .. " to IB " .. ib.head .. " -- " .. blocksize*16)
-    tt.data:copy(ib, ib.head, tb*blocksize*16, blocksize*16)
-    ib.head = ib.head + blocksize*16
-    DMA.send(ib, DMA.GIF)
-    ib = RM.getDrawBuffer(5000)
-    packets = packets - 1
-    tb = tb + 1
-  end
-
-  if remain > 0 then
-    local base = tb*blocksize*16
-    GIF.tag(ib, GIF.IMAGE, remain, false, {1})
-    print("copy from TT " .. base .. " to IB " .. ib.head .. " -- " .. remain*16)
-    tt.data:copy(ib, ib.head, base, remain*16)
-    ib.head = ib.head + remain*16
-  end
-
-  GIF.texflush(ib)
-  DMA.send(ib, DMA.GIF)
-  print("LOAD TEX: DMA send")
-
-  return tt
-end
-
 function PS2PROG.start()
   testTex = D2D.loadTexture("host:test.tga", 64, 64)
-  fnt = loadTexture("host:bigfont.tga", 256, 64)
+  fnt = D2D.loadTexture("host:bigfont.tga", 256, 64)
   DMA.init(DMA.GIF)
   gs = GS.setOutput(640, 448, GS.INTERLACED, GS.NTSC)
   local fb1 = VRAM.buffer(640, 448, GS.PSM24, 256)
@@ -96,12 +33,12 @@ function PS2PROG.start()
   D2D:clearColour(0x2b, 0x2b, 0x2b)
 end
 
-xx = -200
+xx = 200
 local dt = 1/60
 function PS2PROG.frame()
   D2D:frameStart(gs)
   D2D:setColour(0x80,0x80,0x80,0x80)
-  D2D:sprite(testTex, xx, -200, 200, 200, 0, 0, 1, 1)
+  D2D:sprite(testTex, xx, 200, 200, 200, 0, 0, 1, 1)
   D2D:sprite(fnt, 50, 100, 256, 64, 0, 0, 1, 1)
   D2D:frameEnd(gs)
   print("tris/frame = " .. D2D.prev.rawtri .. ", KC=" .. D2D.prev.kc)

--- a/src/main.c
+++ b/src/main.c
@@ -109,11 +109,11 @@ int ps2luaprog_onframe(lua_State *l) {
   lua_getglobal(l, "PS2PROG");
   lua_pushstring(l, "frame");
   lua_gettable(l, -2);
-  /* 
+  /*
   int type = lua_type(l, -1);
   info("frame fn has type :: %s (%d)", lua_typename(l, type), type);
   */
-  
+
   int rc = lua_pcall(l, 0, 0, 0);
 
   if (rc) {
@@ -133,7 +133,6 @@ int ps2luaprog_onframe(lua_State *l) {
   printf("[INFO] " m "\n", ##__VA_ARGS__);                                     \
   scr_printf(m "\n", ##__VA_ARGS__)
 #endif
-
 
 int ps2luaprog_is_running(lua_State *l) { return 1; }
 

--- a/src/main.c
+++ b/src/main.c
@@ -183,7 +183,7 @@ int main(int argc, char *argv[]) {
       logerr("invalid ELF path in argv[0]: %s", argv[0]);
     }
     strncpy(base_path, argv[0], last_sep);
-    base_path[last_sep+1] = 0;
+    base_path[last_sep + 1] = 0;
   }
 
   sprintf(init_script, "%sscript/ps2init.lua", base_path);

--- a/src/main.c
+++ b/src/main.c
@@ -182,8 +182,11 @@ int main(int argc, char *argv[]) {
     if (last_sep == -1) {
       logerr("invalid ELF path in argv[0]: %s", argv[0]);
     }
-    strncpy(base_path, argv[0], last_sep);
-    base_path[last_sep + 1] = 0;
+    if (last_sep + 2 >= 30) {
+      fatal("base path too long!");
+    }
+    strncpy(base_path, argv[0], last_sep + 1);
+    base_path[last_sep + 2] = 0;
   }
 
   sprintf(init_script, "%sscript/ps2init.lua", base_path);

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,7 @@
 #include "pad.h"
 #include "script.h"
 
+char base_path[30] = "host:";
 char init_script[150];
 char main_script[150];
 
@@ -169,7 +170,6 @@ int main(int argc, char *argv[]) {
   for (int i = 0; i < argc; i++) {
     info("arg %d) %s", i, argv[i]);
   }
-  char *base_path = "host:";
   if (argc != 0) {
     int len = strlen(argv[0]);
     int last_sep = last_index_of(argv[0], len, '/');
@@ -182,7 +182,8 @@ int main(int argc, char *argv[]) {
     if (last_sep == -1) {
       logerr("invalid ELF path in argv[0]: %s", argv[0]);
     }
-    base_path = argv[0] + last_sep;
+    strncpy(base_path, argv[0], last_sep);
+    base_path[last_sep+1] = 0;
   }
 
   sprintf(init_script, "%sscript/ps2init.lua", base_path);

--- a/src/main.c
+++ b/src/main.c
@@ -18,9 +18,11 @@
 #include "pad.h"
 #include "script.h"
 
-char base_path[30] = "host:";
-char init_script[150];
-char main_script[150];
+#define BASE_PATH_MAX_LEN 60
+#define FILE_NAME_MAX_LEN 150
+char base_path[BASE_PATH_MAX_LEN] = "host:";
+char init_script[FILE_NAME_MAX_LEN];
+char main_script[FILE_NAME_MAX_LEN];
 
 #ifndef NO_SCREEN_PRINT
 #ifdef info
@@ -97,8 +99,8 @@ int ps2luaprog_init(lua_State *l) {
 int ps2luaprog_onstart(lua_State *l) {
   lua_getglobal(l, "PS2PROG");
   lua_pushstring(l, "start");
-  lua_gettable(l, -2);
-  int type = lua_type(l, -1);
+  // lua_gettable(l, -2);
+  // int type = lua_type(l, -1);
   // info("start fn has type :: %s (%d)", lua_typename(l, type), type);
   int rc = lua_pcall(l, 0, 0, 0);
   if (rc) {
@@ -112,8 +114,8 @@ int ps2luaprog_onstart(lua_State *l) {
 int ps2luaprog_onframe(lua_State *l) {
   lua_getglobal(l, "PS2PROG");
   lua_pushstring(l, "frame");
-  lua_gettable(l, -2);
-  int type = lua_type(l, -1);
+  // lua_gettable(l, -2);
+  // int type = lua_type(l, -1);
   // info("frame fn has type :: %s (%d)", lua_typename(l, type), type);
   //
   int rc = lua_pcall(l, 0, 0, 0);
@@ -182,15 +184,15 @@ int main(int argc, char *argv[]) {
     if (last_sep == -1) {
       logerr("invalid ELF path in argv[0]: %s", argv[0]);
     }
-    if (last_sep + 2 >= 30) {
+    if (last_sep + 2 >= BASE_PATH_MAX_LEN) {
       fatal("base path too long!");
     }
     strncpy(base_path, argv[0], last_sep + 1);
     base_path[last_sep + 2] = 0;
   }
 
-  sprintf(init_script, "%sscript/ps2init.lua", base_path);
-  sprintf(main_script, "%sscript/main.lua", base_path);
+  snprintf(init_script, FILE_NAME_MAX_LEN, "%sscript/ps2init.lua", base_path);
+  snprintf(main_script, FILE_NAME_MAX_LEN, "%sscript/main.lua", base_path);
 
   char *startup = main_script;
   if (argc > 1) {


### PR DESCRIPTION
Resolves #14 

Better path handling for startup and script loading. Get the working directory from `argv[0]`, or if `argc == 0` we assume we are running from ps2link and use `host:` as our working directory.

In theory you can override the startup script with the first program argument but I don't know how this would be done in practice. ps2link does not currently support passing program arguments at all but in a perfect world this would be the optimal way to quickly launch different scripts!

Also some misc script cleanup, and more things now get printed to the PS2 screen on startup.