### PR TITLE
Better DMA Source Chains

### DIFF
--- a/script/draw2d.lua
+++ b/script/draw2d.lua
@@ -21,6 +21,7 @@ local draw = {
   rawtri = 0,
   dmaTagQws = 0,
   dmaTagQwPtr = 0,
+  dmaCntStart = 0,
   isInCnt = false,
   prev = {
     kc = 0,
@@ -37,7 +38,8 @@ end
 function draw:endCnt()
   if self.isInCnt then
     local lw = self.buf:read(self.dmaTagQwPtr)
-    local qwc = math.floor(self.buf.head / 16)
+    local bytes = self.buf.head - self.dmaTagQwPtr
+    local qwc = math.floor(bytes / 16)
     if self.buf.head % 16 ~= 0 then
       qwc = qwc + 1
     end
@@ -142,6 +144,7 @@ function draw:triangle(x1, y1, x2, y2, x3, y3)
 end
 
 function draw:kick()
+  print("kick")
   self:updateLastTagLoops()
   self:endCnt()
   self:dmaEnd()
@@ -177,7 +180,7 @@ end
 function draw.vramAllocTexture(tt)
   local texVramSize = tt.width*tt.height*4
   tt.basePtr = VRAM.alloc(texVramSize, 256)
-  print("LOAD TEX: got texture VRAM addr = " .. tt.basePtr)
+  print("TEXTURE: got texture VRAM addr = " .. tt.basePtr)
 end
 
 function draw:uploadTexture(tt)
@@ -202,7 +205,6 @@ function draw:uploadTexture(tt)
   local blocksize = math.floor(4496/16)
   local packets = math.floor(qwc / blocksize)
   local remain = qwc % blocksize
-  print("LOAD TEX: transmitting in " .. packets .. " packets with " .. remain .. " left")
 
   local tb = 0
   local imgAddr = tt.data.addr
@@ -228,7 +230,6 @@ function draw:uploadTexture(tt)
   GIF.texflush(self.buf)
   -- TODO: this kick should be optional?
   -- self:kick()
-  print("LOAD TEX: DMA send")
 
   return true
 end

--- a/script/draw2d.lua
+++ b/script/draw2d.lua
@@ -134,7 +134,7 @@ function draw:kick()
   if self.buf.head % 16 ~= 0 then
     qwc = qwc + 1
   end
-  self.buf:write(self.dmaTagQwPtr, lw + qwc - 2)
+  self.buf:write(self.dmaTagQwPtr, lw + qwc - 1)
   draw:dmaEnd()
   DMA.sendChain(self.buf, DMA.GIF)
   self:newBuffer()

--- a/script/draw2d.lua
+++ b/script/draw2d.lua
@@ -144,7 +144,6 @@ function draw:triangle(x1, y1, x2, y2, x3, y3)
 end
 
 function draw:kick()
-  print("kick")
   self:updateLastTagLoops()
   self:endCnt()
   self:dmaEnd()

--- a/script/draw2d.lua
+++ b/script/draw2d.lua
@@ -2,39 +2,56 @@ local GIF = require("gif")
 local P = require("ps2const")
 local VRAM = require("vram")
 
+-- enum for how this script tracks current
+-- drawing mode to minimize GIFTag swapping
 local DRAW_NONE = 0
 local DRAW_GEOM = 1
 local DRAW_SPRITE = 2
 
+-- GS Registers to set when drawing geometry
 local DRAW_FMT_GEOM = {1,5,5,5}
+-- GS Registers to set when drawing SPRITE primitives
 local DRAW_FMT_SPRITE = {2,1,5,2,1,5}
+-- Size of each drawbuffer before we have to split it
 local DB_SIZE = 20000
 
+-- Local draw state
 local draw = {
+  -- current colour
   col = {r=255, g=255, b=255, a=0x80},
+  -- current state
   state = DRAW_NONE,
+  -- number of loops in current GIFTag
   loopCount = 0,
+  -- pointer to start of current GIFTag in active buffer
   tagLoopPtr = -1,
+  -- VRAM addr of texture we are currently drawing
   currentTexPtr = 0,
-  buf = {},
+  -- current drawbuffer (initialized each frame)
+  buf = nil,
+  -- how many drawbuffer "kick"s this frame
   kc = 0,
+  -- how many raw triangles we pushed this frame
   rawtri = 0,
-  dmaTagQws = 0,
+  -- pointer to start of current DMATag in active buffer
   dmaTagQwPtr = 0,
-  dmaCntStart = 0,
+  -- are we currently in a CNT DMATag?
   isInCnt = false,
+  -- metrics from previous frame
   prev = {
     kc = 0,
     rawtri = 0,
   }
 }
 
+-- start new CNT DMATag for standard GIFTag registers data
 function draw:newCnt()
   self.dmaTagQwPtr = self.buf.head
   self:dmaTagRaw(DMA.CNT, 0, 0)
   self.isInCnt = true
 end
 
+-- end current CNT and calculate number of QWs
 function draw:endCnt()
   if self.isInCnt then
     local lw = self.buf:read(self.dmaTagQwPtr)
@@ -43,10 +60,15 @@ function draw:endCnt()
     if self.buf.head % 16 ~= 0 then
       qwc = qwc + 1
     end
+    -- update the DMATag with the number of QWs
     self.buf:write(self.dmaTagQwPtr, lw + qwc - 1)
   end
 end
 
+-- put a DMATag in the current draw buffer
+--  tt   - DMA type (eg DMA.CNT, DMA.REF)
+--  qwc  - number of quadwords
+--  addr - addr field (meaning depends on type, 0 for CNT)
 function draw:dmaTagRaw(tt, qwc, addr)
   self.buf:pushint(qwc + tt)
   self.buf:pushint(addr)
@@ -54,23 +76,23 @@ function draw:dmaTagRaw(tt, qwc, addr)
   self.buf:pushint(0)
 end
 
-
+-- put a DMATag with type END in the draw buffer
 function draw:dmaEnd()
   self:dmaTagRaw(DMA.END, 0, 0)
 end
 
+-- get a new drawbuffer, called at frame start or after "kick"
 function draw:newBuffer()
   self.state = DRAW_NONE
   self.loopCount = 0
   self.tagLoopPtr = -1
   self.buf = RM.getDrawBuffer(DB_SIZE)
+  -- start a CNT by default, if we end the CNT without pushing anything 
+  -- into it this is has no effect
   self:newCnt()
 end
 
-function draw:getBuffer()
-  return self.buf
-end
-
+-- set current draw colour
 function draw:setColour(r,g,b,a)
   self.col.r = math.floor(r)
   self.col.g = math.floor(g)
@@ -78,26 +100,33 @@ function draw:setColour(r,g,b,a)
   self.col.a = math.floor(a)
 end
 
+-- draw a rectangle
 function draw:rect(x, y, w, h)
   x = math.floor(x)
   y = math.floor(y)
+  -- TODO: optimize with a SPRITE primitive
   draw:triangle(x, y, x+w, y, x, y+h)
   draw:triangle(x, y+h, x+w, y+h, x+w, y)
 end
 
+-- convert a 32bit floating point number to a fixed point coordinate + offset
 function toCoord(i)
   local ii = math.floor(i)
   local fi = math.floor((i%1)*0xf)
   return 0x8000 + (ii*16) + fi
 end
 
+-- draw a sprite
 function draw:sprite(tex, x, y, w, h, u1, v1, u2, v2)
   if self.loopCount > 10000 then self:kick() end
   if self.buf.size - self.buf.head < 80 then self:kick() end
+  -- if we aren't in a GIFTag drawing sprites for the current texture then...
   if self.state ~= DRAW_SPRITE or self.currentTexPtr ~= tex.basePtr then
+    -- cleanup previous tag
     if self.state ~= DRAW_NONE then
       draw:updateLastTagLoops() 
     end
+    -- setup texture drawing registers
     self.currentTexPtr = tex.basePtr
     local pb = math.floor(tex.basePtr/64)
     local pw = math.floor(tex.width/64)
@@ -113,6 +142,7 @@ function draw:sprite(tex, x, y, w, h, u1, v1, u2, v2)
     self.loopCount = 0
     self.state = DRAW_SPRITE
   end
+  -- push geometry, colour and ST to drawbuffer
   GIF.packedST(self.buf, u1, v1)
   GIF.packedRGBAQ(self.buf, self.col.r, self.col.g, self.col.b, self.col.a)
   GIF.packedXYZ2(self.buf, toCoord(x-320), toCoord(y-224), 0)
@@ -122,19 +152,24 @@ function draw:sprite(tex, x, y, w, h, u1, v1, u2, v2)
   self.loopCount = self.loopCount + 1
 end
 
+-- draw triangle
 function draw:triangle(x1, y1, x2, y2, x3, y3)
   if self.loopCount > 10000 then self:kick() end
   if self.buf.size - self.buf.head < 80 then self:kick() end
+  -- if we are not currently drawing raw geometry then...
   if self.state ~= DRAW_GEOM then
+    -- cleanup previous GIFTag
     if self.state ~= DRAW_NONE then
       draw:updateLastTagLoops() 
     end
+    -- setup GIFTag for drawing triangles
     GIF.tag(self.buf, 0, 1, false, {0xe})
     GIF.primAd(self.buf, P.PRIM.TRI, false, false, false)
     self.tagLoopPtr = GIF.tag(self.buf, 0, 1, false, DRAW_FMT_GEOM)
     self.loopCount = 0
     self.state = DRAW_GEOM
   end
+  -- push PACKED triangle data into draw buffer
   GIF.packedRGBAQ(self.buf, self.col.r, self.col.g, self.col.b, self.col.a)
   GIF.packedXYZ2(self.buf, toCoord(x1-320), toCoord(y1-224), 0)
   GIF.packedXYZ2(self.buf, toCoord(x2-320), toCoord(y2-224), 0)
@@ -143,27 +178,37 @@ function draw:triangle(x1, y1, x2, y2, x3, y3)
   self.rawtri = self.rawtri + 1
 end
 
+-- submit the current drawbuffer for rendering
 function draw:kick()
+  -- cleanup current GIFTag
   self:updateLastTagLoops()
+  -- end any active CNT (does nothing if no CNT DMATag active)
   self:endCnt()
+  -- add DMA END tag
   self:dmaEnd()
   DMA.sendChain(self.buf, DMA.GIF)
+  -- refresh our drawbuffer, basically free so no concerns doing this at the
+  --  end of the frame
   self:newBuffer()
   self.kc = self.kc + 1
 end
 
+-- cleanup current GIFTag with all relevant data
 function draw:updateLastTagLoops()
   if self.tagLoopPtr >= 0 then
     local nloop = self.buf:read(self.tagLoopPtr) 
+    -- if this GIFTag has EOP flag set
     if nloop - 0x8000 > 0 then
-      print("kick EOP")
+      -- write the number of loops back with EOP flag set 
       self.buf:write(self.tagLoopPtr, 0x8000 + self.loopCount)
     else
+      -- otherwise just write the number of loops
       self.buf:write(self.tagLoopPtr, self.loopCount)
     end
   end
 end
 
+-- load a texture into EE memory
 function draw.loadTexture(fname, w, h)
   local tt = {
     width = w,
@@ -176,19 +221,23 @@ function draw.loadTexture(fname, w, h)
   return tt 
 end
 
+-- get VRAM address for texture
 function draw.vramAllocTexture(tt)
+  -- only works for power of 2 textures @ psm32!!!!!
   local texVramSize = tt.width*tt.height*4
   tt.basePtr = VRAM.alloc(texVramSize, 256)
   print("TEXTURE: got texture VRAM addr = " .. tt.basePtr)
 end
 
+-- upload a texture that has been VRAM allocated into GS memory
 function draw:uploadTexture(tt)
   if tt.basePtr == nil then
     error("cannot upload texture that has not been allocated")
   end
-  -- only works for power of 2 textures @ psm32!!!!!
   if self.buf.size - self.buf.head < 7 then self:kick() end
+  -- ASSUME: DMATag CNT is active
 
+  -- setup GS texture transfer registers for upload
   GIF.tag(self.buf, GIF.PACKED, 4, false, {0xe})
   GIF.bitBltBuf(self.buf, math.floor(tt.basePtr/64), math.floor(tt.width/64), tt.format)
   GIF.trxPos(self.buf,0,0,0,0,0)
@@ -197,18 +246,22 @@ function draw:uploadTexture(tt)
 
   self:endCnt()
 
-  -- ASSUMPTION about format!
+  -- ASSUME: format is PSM32!
   local eeSize = tt.width*tt.height*4
   local qwc = math.floor(eeSize / 16)
   if qwc % 16 ~= 0 then qwc = qwc + 1 end
   local blocksize = math.floor(4496/16)
+  -- number of whole GIFTags this transfer will take
   local packets = math.floor(qwc / blocksize)
+  -- plus a possible remainder
   local remain = qwc % blocksize
 
   local tb = 0
   local imgAddr = tt.data.addr
   while packets > 0 do
     if self.buf.size - self.buf.head < 4 then self:kick() end
+    -- for each fullsized packet, add a CNT with the GIFTag describing IMAGE
+    --  data, followed by DMATag REF pointing to EE memory
     self:dmaTagRaw(DMA.CNT, 1, 0) 
     GIF.tag(self.buf, GIF.IMAGE, blocksize, false, {0}) 
     self:dmaTagRaw(DMA.REF, blocksize, imgAddr)
@@ -217,6 +270,7 @@ function draw:uploadTexture(tt)
     tb = tb + 1
   end
 
+  -- if there was any remainder, upload seperately
   if remain > 0 then
     if self.buf.size - self.buf.head < 4 then self:kick() end
     local base = tb*blocksize*16
@@ -225,14 +279,14 @@ function draw:uploadTexture(tt)
     self:dmaTagRaw(DMA.REF, remain, imgAddr)
   end
 
+  -- start a new CNT and add a texflush command
   self:newCnt()
   GIF.texflush(self.buf)
-  -- TODO: this kick should be optional?
-  -- self:kick()
 
   return true
 end
 
+-- setup frame and setup drawbuffer
 function draw:frameStart(gs)
   self.kc = 0
   self.rawtri = 0
@@ -240,6 +294,7 @@ function draw:frameStart(gs)
   self.buf:frameStart(640, 448, self.clearR, self.clearG, self.clearB)
 end
 
+-- setup frame end, kick drawbuffer
 function draw:frameEnd(gs)
   self.buf:frameEnd(gs)
   self:kick()
@@ -247,6 +302,7 @@ function draw:frameEnd(gs)
   self.prev.rawtri = self.rawtri
 end
 
+-- set clear colour
 function draw:clearColour(r, g, b)
   self.clearR = r
   self.clearG = g

--- a/script/main.lua
+++ b/script/main.lua
@@ -1,5 +1,5 @@
 
-require("stress")
+require("texture")
 return {}
 
 -- default entrypoint - do nothing and hang!

--- a/script/stress.lua
+++ b/script/stress.lua
@@ -30,7 +30,7 @@ function PS2PROG.start()
   GS.setBuffers(fb1, fb2, zb)
   D2D:clearColour(0x2b, 0x2b, 0x2b)
 
-  local dd = 100
+  local dd = 2
   local dx = math.floor(640/dd)
   local dy = math.floor(448/dd)
   for x=-320,320,dx do

--- a/script/stress.lua
+++ b/script/stress.lua
@@ -30,7 +30,7 @@ function PS2PROG.start()
   GS.setBuffers(fb1, fb2, zb)
   D2D:clearColour(0x2b, 0x2b, 0x2b)
 
-  local dd = 2
+  local dd = 100
   local dx = math.floor(640/dd)
   local dy = math.floor(448/dd)
   for x=-320,320,dx do

--- a/script/texture.lua
+++ b/script/texture.lua
@@ -27,8 +27,10 @@ xx = 200
 local dt = 1/60
 function PS2PROG.frame()
   D2D:frameStart(gs)
-  D2D:uploadTexture(testTex)
-  D2D:uploadTexture(fnt)
+  res = D2D:uploadTexture(testTex)
+  if res then testTex.resident = true end
+  res = D2D:uploadTexture(fnt)
+  if res then fnt.resident = true end
   D2D:setColour(0x80,0x80,0x80,0x80)
   D2D:sprite(testTex, xx, 200, 200, 200, 0, 0, 1, 1)
   D2D:sprite(fnt, 50, 100, 256, 64, 0, 0, 1, 1)

--- a/script/texture.lua
+++ b/script/texture.lua
@@ -4,19 +4,7 @@ local P = require("ps2const")
 local D2D = require("draw2d")
 local VRAM = require("vram")
 
-function makeTex(w, h, fill)
-  local t = {}
-  for x=0,w,1 do
-    for y=0,h,1 do
-      t[y*w + x] = fill
-    end
-  end
-  return t
-end
-
-
 local gs = nil
---local tex = makeTex(64, 64, 0x800000ff)
 local testTex = {}
 local fnt = nil
 
@@ -41,7 +29,7 @@ function PS2PROG.frame()
   D2D:sprite(testTex, xx, 200, 200, 200, 0, 0, 1, 1)
   D2D:sprite(fnt, 50, 100, 256, 64, 0, 0, 1, 1)
   D2D:frameEnd(gs)
-  print("tris/frame = " .. D2D.prev.rawtri .. ", KC=" .. D2D.prev.kc)
+  print("tris/frame = " .. D2D.prev.rawtri .. ", KC=" .. D2D.prev.kc .. ", FPS=" .. FPS)
 
   if PAD.held(PAD.LEFT) then xx = xx - 50*dt end
   if PAD.held(PAD.RIGHT) then xx = xx + 50*dt end

--- a/script/texture.lua
+++ b/script/texture.lua
@@ -19,12 +19,16 @@ function PS2PROG.start()
   local zb = VRAM.buffer(640, 448, GS.PSMZ24, 256)
   GS.setBuffers(fb1, fb2, zb)
   D2D:clearColour(0x2b, 0x2b, 0x2b)
+  D2D.vramAllocTexture(testTex)
+  D2D.vramAllocTexture(fnt)
 end
 
 xx = 200
 local dt = 1/60
 function PS2PROG.frame()
   D2D:frameStart(gs)
+  D2D:uploadTexture(testTex)
+  D2D:uploadTexture(fnt)
   D2D:setColour(0x80,0x80,0x80,0x80)
   D2D:sprite(testTex, xx, 200, 200, 200, 0, 0, 1, 1)
   D2D:sprite(fnt, 50, 100, 256, 64, 0, 0, 1, 1)

--- a/src/dmalua.c
+++ b/src/dmalua.c
@@ -91,7 +91,7 @@ int dma_lua_init(lua_State *l) {
   lua_pushinteger(l, DMA_CHANNEL_VIF1);
   lua_setfield(l, -2, "VIF1");
 
-  lua_pushinteger(l, 1 << 24); 
+  lua_pushinteger(l, 1 << 24);
   lua_setfield(l, -2, "CNT");
   lua_pushinteger(l, 7 << 24);
   lua_setfield(l, -2, "END");
@@ -101,7 +101,6 @@ int dma_lua_init(lua_State *l) {
   lua_setfield(l, -2, "REFE");
   lua_pushinteger(l, 2 << 24);
   lua_setfield(l, -2, "NEXT");
-
 
   lua_setglobal(l, "DMA");
   return 0;

--- a/src/dmalua.c
+++ b/src/dmalua.c
@@ -59,7 +59,7 @@ static int dma_send_chain_buffer(lua_State *l) {
   int channel = lua_tointeger(l, 2);
 
   // print buffer for debugging
-  print_buffer(ptr, head / 16);
+  // print_buffer(ptr, head / 16);
 
   // info("DMA send :: sending %d qwords on channel %d", head/16, channel);
   dma_channel_send_chain(channel, ptr, head / 16, 0, 0);
@@ -91,15 +91,15 @@ int dma_lua_init(lua_State *l) {
   lua_pushinteger(l, DMA_CHANNEL_VIF1);
   lua_setfield(l, -2, "VIF1");
 
-  lua_pushinteger(l, 1 << 24);
+  lua_pushinteger(l, 1 << 28);
   lua_setfield(l, -2, "CNT");
-  lua_pushinteger(l, 7 << 24);
+  lua_pushinteger(l, 7 << 28);
   lua_setfield(l, -2, "END");
-  lua_pushinteger(l, 3 << 24);
+  lua_pushinteger(l, 3 << 28);
   lua_setfield(l, -2, "REF");
   lua_pushinteger(l, 0);
   lua_setfield(l, -2, "REFE");
-  lua_pushinteger(l, 2 << 24);
+  lua_pushinteger(l, 2 << 28);
   lua_setfield(l, -2, "NEXT");
 
   lua_setglobal(l, "DMA");

--- a/src/main.c
+++ b/src/main.c
@@ -277,13 +277,13 @@ int main(int argc, char *argv[]) {
     dma_wait_fast();
     ps2luaprog_onframe(L);
     // may be required? -- dma_wait_fast();
-    info("WAIT DRAW");
+    trace("WAIT DRAW");
     draw_wait_finish();
-    info("WAIT VSYNC");
+    trace("WAIT VSYNC");
     graph_wait_vsync();
-    info("FLIP");
+    trace("FLIP");
     gs_flip();
-    info("FLIPOUT");
+    trace("FLIPOUT");
     frame_count += 1;
     clock_t now = clock();
     if (now > next_fps_report) {

--- a/src/main.c
+++ b/src/main.c
@@ -22,11 +22,11 @@
 static clock_t __time_now;
 
 #define BENCH_START(vname) clock_t vname = clock()
-#define BENCH_INFO(vname, m) do { \
-  __time_now = clock(); \
-  info(m, ((float)__time_now - vname) / (float)CLOCKS_PER_SEC); \
-}while(0)
-  
+#define BENCH_INFO(vname, m)                                                   \
+  do {                                                                         \
+    __time_now = clock();                                                      \
+    info(m, ((float)__time_now - vname) / (float)CLOCKS_PER_SEC);              \
+  } while (0)
 
 #define BASE_PATH_MAX_LEN 60
 #define FILE_NAME_MAX_LEN 150
@@ -268,7 +268,6 @@ int main(int argc, char *argv[]) {
 
   lua_pushinteger(L, 0);
   lua_setglobal(L, "FPS");
-
 
   int frame_count = 0;
   clock_t next_fps_report = clock() + CLOCKS_PER_SEC;

--- a/src/main.c
+++ b/src/main.c
@@ -266,6 +266,9 @@ int main(int argc, char *argv[]) {
   lua_pushnil(L);
   lua_setglobal(L, "dbgPrint");
 
+  lua_pushinteger(L, 0);
+  lua_setglobal(L, "FPS");
+
 
   int frame_count = 0;
   clock_t next_fps_report = clock() + CLOCKS_PER_SEC;
@@ -275,13 +278,13 @@ int main(int argc, char *argv[]) {
     dma_wait_fast();
     ps2luaprog_onframe(L);
     // may be required? -- dma_wait_fast();
-    trace("WAIT DRAW");
+    info("WAIT DRAW");
     draw_wait_finish();
-    trace("WAIT VSYNC");
+    info("WAIT VSYNC");
     graph_wait_vsync();
-    trace("FLIP");
+    info("FLIP");
     gs_flip();
-    trace("FLIPOUT");
+    info("FLIPOUT");
     frame_count += 1;
     clock_t now = clock();
     if (now > next_fps_report) {

--- a/src/tga.c
+++ b/src/tga.c
@@ -71,6 +71,8 @@ int load_tga_lua(lua_State *l) {
   lua_setfield(l, -2, "size");
   lua_pushlightuserdata(l, b);
   lua_setfield(l, -2, "ptr");
+  lua_pushinteger(l, (int) b);
+  lua_setfield(l, -2, "addr");
 
   luaL_getmetatable(l, "ps2.buffer");
   lua_setmetatable(l, -2);


### PR DESCRIPTION
Resolves #18 

* Add support from DMA REF tags to upload texture data without EE RAM copy
* Refactor Draw2D texture API to split out loading (EE RAM), allocating (VRAM) and uploading (VRAM)
* Solid commenting pass on draw2d.lua