### PR TITLE
Math - Vector 2, Vector 3 and Matrix 3x3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,8 @@ lint:
 .PHONY: lualint
 lualint:
 	luac5.1 -p script/*.lua
+	luac5.1 -p script/math/*.lua
+	luac5.1 -p script/eg/*.lua
 
 .PHONY: format
 format:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ LUA_BRANCH=ee-v5.4.4
 VERSION?=$(shell git rev-parse --short HEAD)
 ISO_FLAGS?=-l --allow-lowercase -A "game by Tom Marks" -V "LGJ21 $(VERSION)"
 
+LUA_FILES=$(shell find script -type f -name "*.lua")
+
 include .lintvars
 
 dist: $(BIN) assets
@@ -76,9 +78,7 @@ lint:
 
 .PHONY: lualint
 lualint:
-	luac5.1 -p script/*.lua
-	luac5.1 -p script/math/*.lua
-	luac5.1 -p script/eg/*.lua
+	luac5.1 -p $(LUA_FILES)
 
 .PHONY: format
 format:

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ lint:
 
 .PHONY: lualint
 lualint:
-	luac5.1 -p $(LUA_FILES)
+	luac5.3 -p $(LUA_FILES)
 
 .PHONY: format
 format:

--- a/script/eg/math.lua
+++ b/script/eg/math.lua
@@ -1,0 +1,119 @@
+
+local GIF = require("gif")
+local P = require("ps2const")
+local D2D = require("draw2d")
+local VRAM = require("vram")
+local M = require("ps2math")
+
+local gs = nil
+
+function tests()
+  local a = M.mat3()
+  assert(a[0] == 1)
+  assert(a[1] == 0)
+  assert(a[3] == 0)
+  assert(a[4] == 1)
+  local b = M.mat3({ {1,2,3},{0,0,0},{0,0,0} })
+  M.mat3_mt.add(a, b)
+  local c = M.mat3({ {2,2,3},{0,1,0},{0,0,1} })
+  assert(a:equal(c))
+  assert(a[2] == a:get(2, 0))
+  assert(a[8] == a:get(2,2))
+  local ii = M.mat3()
+  local x = M.mat3()
+  x:copy(a)
+  x:mul(ii)
+  assert(a:equal(x))
+
+  local ta = M.mat3({ {5,12,9},{2,4.2,1},{11,8,0.2} })
+  local tb = M.mat3({ {7,12,122},{0.1,17,8},{5,100,-2} })
+  local tres = M.mat3({ {81.2,1164,688},{19.42,195.4,275.6},{78.8,288,1405.6} })
+  ta:mul(tb)
+  assert(ta:equal(tres))
+
+  local va = M.vec3(5,12,7.4)
+  local vb = M.vec3From(va)
+  ii:apply(va)
+  assert(va:equal(vb))
+
+  local ra = M.vec3(12, 8, 1)
+
+  local rx = M.vec3(10.17144 + 10, 10.22456 + 4, 1)
+  local rm = M.mat3({ {math.cos(0.2), -1 * math.sin(0.2), 10}, {math.sin(0.2), math.cos(0.2), 4}, {0,0,1} })
+  -- local rm = M.mat3({ {math.cos(0.2), math.sin(0.2), 0}, {-1 * math.sin(0.2), math.cos(0.2), 0}, {10, 4, 1} })
+  rm:apply(ra)
+  print(ra:__string() .. " -> " .. rx:__string())
+  assert(ra:equal(rx))
+end
+
+function PS2PROG.start()
+  PS2PROG.logLevel(5)
+  DMA.init(DMA.GIF)
+  gs = GS.setOutput(640, 448, GS.INTERLACED, GS.NTSC)
+  local fb1 = VRAM.mem:framebuffer(640, 448, GS.PSM24, 2048)
+  local fb2 = VRAM.mem:framebuffer(640, 448, GS.PSM24, 2048)
+  local zb = VRAM.mem:framebuffer(640, 448, GS.PSMZ24, 2048)
+  GS.setBuffers(fb1, fb2, zb)
+  D2D:screenDimensions(640, 448)
+  D2D:clearColour(0x2b, 0x2b, 0x2b)
+  local db = RM.alloc(200 * 1024)
+  D2D:bindBuffer(db)
+end
+
+local done = false
+local pos = M.vec2(100, 100)
+local angle = 0
+local fwd = M.vec2(1, 0)
+local work = M.vec2(0, 0)
+local w2 = M.vec2(0,0)
+local rv = 0.07
+local v = 1.6
+
+local TAU = 2 * math.pi
+
+
+function stepPlayer()
+  if PAD.held(PAD.LEFT) then
+    angle = angle - rv
+  elseif PAD.held(PAD.RIGHT) then
+    angle = angle + rv
+  end
+  local velocity = 0
+  if PAD.held(PAD.UP) then velocity = v end
+  if angle > TAU then angle = angle - TAU end
+  if angle < 0 then angle = angle + TAU end
+  MATH_C_LIB.copyVec2(work.buf, fwd.buf)
+  work:rotate(angle)
+  work:scale(velocity)
+  pos:add(work)
+end
+
+function PS2PROG.frame()
+  if not done then
+    done = true
+
+    local v1 = M.vec2(5, 4)
+    local v2 = M.vec2(7, 7)
+    local perp = M.vec2(-11, 12)
+    v1:add(v2)
+    local l = v1:length()
+    local d = v1:dot(v2)
+    LOG.info("vector add result: " .. tostring(v1))
+    LOG.info("len = " .. l .. ", dot = " .. d)
+    LOG.info("zero = " .. v1:dot(perp))
+    v1:copyRotate(1)
+    tests()
+  end
+  D2D:frameStart(gs)
+  stepPlayer()
+  D2D:setColour(255,0,0,0x80)
+  D2D:rect(pos.x, pos.y, 20, 20)
+  MATH_C_LIB.copyVec2(w2.buf, fwd.buf)
+  w2:rotate(angle)
+  w2:scale(60)
+  D2D:setColour(0, 255, 255, 0x80)
+  D2D:rect(pos.x + w2.x + 10, pos.y + w2.y + 10, 4, 4)
+  D2D:frameEnd(gs)
+end
+
+

--- a/script/eg/math.lua
+++ b/script/eg/math.lua
@@ -42,7 +42,7 @@ function tests()
   local rm = M.mat3({ {math.cos(0.2), -1 * math.sin(0.2), 10}, {math.sin(0.2), math.cos(0.2), 4}, {0,0,1} })
   -- local rm = M.mat3({ {math.cos(0.2), math.sin(0.2), 0}, {-1 * math.sin(0.2), math.cos(0.2), 0}, {10, 4, 1} })
   rm:apply(ra)
-  print(ra:__string() .. " -> " .. rx:__string())
+  print(tostring(ra) .. " -> " .. tostring(rx))
   assert(ra:equal(rx))
 end
 

--- a/script/eg/math.lua
+++ b/script/eg/math.lua
@@ -8,7 +8,7 @@ local M = require("ps2math")
 local gs = nil
 
 function PS2PROG.start()
-  PS2PROG.logLevel(5)
+  PS2PROG.logLevel(LOG.debugLevel)
   DMA.init(DMA.GIF)
   gs = GS.setOutput(640, 448, GS.INTERLACED, GS.NTSC)
   local fb1 = VRAM.mem:framebuffer(640, 448, GS.PSM24, 2048)

--- a/script/eg/math.lua
+++ b/script/eg/math.lua
@@ -7,45 +7,6 @@ local M = require("ps2math")
 
 local gs = nil
 
-function tests()
-  local a = M.mat3()
-  assert(a[0] == 1)
-  assert(a[1] == 0)
-  assert(a[3] == 0)
-  assert(a[4] == 1)
-  local b = M.mat3({ {1,2,3},{0,0,0},{0,0,0} })
-  M.mat3_mt.add(a, b)
-  local c = M.mat3({ {2,2,3},{0,1,0},{0,0,1} })
-  assert(a:equal(c))
-  assert(a[2] == a:get(2, 0))
-  assert(a[8] == a:get(2,2))
-  local ii = M.mat3()
-  local x = M.mat3()
-  x:copy(a)
-  x:mul(ii)
-  assert(a:equal(x))
-
-  local ta = M.mat3({ {5,12,9},{2,4.2,1},{11,8,0.2} })
-  local tb = M.mat3({ {7,12,122},{0.1,17,8},{5,100,-2} })
-  local tres = M.mat3({ {81.2,1164,688},{19.42,195.4,275.6},{78.8,288,1405.6} })
-  ta:mul(tb)
-  assert(ta:equal(tres))
-
-  local va = M.vec3(5,12,7.4)
-  local vb = M.vec3From(va)
-  ii:apply(va)
-  assert(va:equal(vb))
-
-  local ra = M.vec3(12, 8, 1)
-
-  local rx = M.vec3(10.17144 + 10, 10.22456 + 4, 1)
-  local rm = M.mat3({ {math.cos(0.2), -1 * math.sin(0.2), 10}, {math.sin(0.2), math.cos(0.2), 4}, {0,0,1} })
-  -- local rm = M.mat3({ {math.cos(0.2), math.sin(0.2), 0}, {-1 * math.sin(0.2), math.cos(0.2), 0}, {10, 4, 1} })
-  rm:apply(ra)
-  print(tostring(ra) .. " -> " .. tostring(rx))
-  assert(ra:equal(rx))
-end
-
 function PS2PROG.start()
   PS2PROG.logLevel(5)
   DMA.init(DMA.GIF)
@@ -60,7 +21,6 @@ function PS2PROG.start()
   D2D:bindBuffer(db)
 end
 
-local done = false
 local pos = M.vec2(100, 100)
 local angle = 0
 local fwd = M.vec2(1, 0)
@@ -89,21 +49,6 @@ function stepPlayer()
 end
 
 function PS2PROG.frame()
-  if not done then
-    done = true
-
-    local v1 = M.vec2(5, 4)
-    local v2 = M.vec2(7, 7)
-    local perp = M.vec2(-11, 12)
-    v1:add(v2)
-    local l = v1:length()
-    local d = v1:dot(v2)
-    LOG.info("vector add result: " .. tostring(v1))
-    LOG.info("len = " .. l .. ", dot = " .. d)
-    LOG.info("zero = " .. v1:dot(perp))
-    v1:copyRotate(1)
-    tests()
-  end
   D2D:frameStart(gs)
   stepPlayer()
   D2D:setColour(255,0,0,0x80)

--- a/script/eg/math.lua
+++ b/script/eg/math.lua
@@ -24,8 +24,6 @@ end
 local pos = M.vec2(100, 100)
 local angle = 0
 local fwd = M.vec2(1, 0)
-local work = M.vec2(0, 0)
-local w2 = M.vec2(0,0)
 local rv = 0.07
 local v = 1.6
 
@@ -42,7 +40,7 @@ function stepPlayer()
   if PAD.held(PAD.UP) then velocity = v end
   if angle > TAU then angle = angle - TAU end
   if angle < 0 then angle = angle + TAU end
-  MATH_C_LIB.copyVec2(work.buf, fwd.buf)
+  local work = M.vec2From(fwd)
   work:rotate(angle)
   work:scale(velocity)
   pos:add(work)
@@ -53,7 +51,7 @@ function PS2PROG.frame()
   stepPlayer()
   D2D:setColour(255,0,0,0x80)
   D2D:rect(pos.x, pos.y, 20, 20)
-  MATH_C_LIB.copyVec2(w2.buf, fwd.buf)
+  local w2 = M.vec2From(fwd)
   w2:rotate(angle)
   w2:scale(60)
   D2D:setColour(0, 255, 255, 0x80)

--- a/script/main.lua
+++ b/script/main.lua
@@ -1,3 +1,14 @@
+
+local test_files = {"test.test_mat3x3", "test.test_vec2"}
+function run_unit_tests()
+  for _, name in ipairs(test_files) do
+    local fn = require(name)
+    fn()
+  end
+end
+
+run_unit_tests()
+
 require("eg.math")
 return {}
 

--- a/script/main.lua
+++ b/script/main.lua
@@ -1,7 +1,7 @@
 
 local startup_ok = true
 
-local test_files = {"test_vec2", "test_mat3x3"}
+local test_files = {"test_vec2", "test_mat3x3", "test_vec3"}
 function run_unit_tests()
   local ok = true
   for _, name in ipairs(test_files) do

--- a/script/main.lua
+++ b/script/main.lua
@@ -1,13 +1,22 @@
 
+local startup_ok = true
+
 local test_files = {"test_vec2", "test_mat3x3"}
 function run_unit_tests()
+  local ok = true
   for _, name in ipairs(test_files) do
     local fn = require("test." .. name)
-    fn()
+    if fn() == false then 
+      ok = false 
+    end
   end
+  if not ok then error("failed unit tests!") end
 end
 
-run_unit_tests()
+if pcall(run_unit_tests) ~= true then
+  return {}
+end
+
 
 require("eg.math")
 return {}

--- a/script/main.lua
+++ b/script/main.lua
@@ -1,8 +1,8 @@
 
-local test_files = {"test.test_mat3x3", "test.test_vec2"}
+local test_files = {"test_vec2", "test_mat3x3"}
 function run_unit_tests()
   for _, name in ipairs(test_files) do
-    local fn = require(name)
+    local fn = require("test." .. name)
     fn()
   end
 end

--- a/script/main.lua
+++ b/script/main.lua
@@ -1,4 +1,4 @@
-require("eg.texture")
+require("eg.math")
 return {}
 
 -- default entrypoint - do nothing and hang!

--- a/script/math/mat3.lua
+++ b/script/math/mat3.lua
@@ -32,7 +32,7 @@ function mat3:__tostring()
 end
 
 function mat3.new(x)
-  local buf = RM.alloc(4 * 9) 
+  local buf = RM.gcAlloc(4 * 9) 
   if x == nil then 
     -- if no args initialize to identity matrix
     M.identityMat3(buf)

--- a/script/math/mat3.lua
+++ b/script/math/mat3.lua
@@ -32,7 +32,6 @@ function mat3:__tostring()
 end
 
 function mat3:__eq(other)
-  LOG.info("testing m " .. tostring(self) .. ", " .. tostring(other))
   for i=0,8,1 do
     if M.floatCmp(self[i], other[i]) == false then 
       LOG.info("mismatch @ (" .. i .. ") " .. self[i] .. " -> " .. other[i])

--- a/script/math/mat3.lua
+++ b/script/math/mat3.lua
@@ -20,7 +20,7 @@ function mat3.__newindex(o, k, v)
   end
 end
 
-function mat3:__string()
+function mat3:__tostring()
   base = "[" 
   for i=0,8,1 do
     if i > 0 and i % 3 == 0 

--- a/script/math/mat3.lua
+++ b/script/math/mat3.lua
@@ -31,6 +31,17 @@ function mat3:__tostring()
   return base .. "]"
 end
 
+function mat3:__eq(other)
+  LOG.info("testing m " .. tostring(self) .. ", " .. tostring(other))
+  for i=0,8,1 do
+    if M.floatCmp(self[i], other[i]) == false then 
+      LOG.info("mismatch @ (" .. i .. ") " .. self[i] .. " -> " .. other[i])
+      return false 
+    end
+  end
+  return true
+end
+
 function mat3.new(x)
   local buf = RM.gcAlloc(4 * 9) 
   if x == nil then 
@@ -65,13 +76,6 @@ end
 
 function mat3:copy(from)
   M.copyMat3(self.buf, from.buf)
-end
-
-function mat3:equal(other)
-  for i=0,8,1 do
-    if math.abs(self[i] - other[i]) > 0.0001 then return false end
-  end
-  return true
 end
 
 return mat3

--- a/script/math/mat3.lua
+++ b/script/math/mat3.lua
@@ -1,0 +1,77 @@
+local M = MATH_C_LIB
+
+local mat3 = {}
+
+function mat3.__index(o, k) 
+  local n = tonumber(k)
+  if n ~= nil and n >= 0 and n < 9 then
+    local buf = rawget(o, "buf")
+    return buf:getFloat(n) 
+  else return mat3[k]
+  end
+end
+
+function mat3.__newindex(o, k, v)
+  local n = tonumber(k)
+  if n ~= nil and n >= 0 and n < 9 then
+    local buf = rawget(o, "buf")
+    return buf:setFloat(n, v) 
+  else return rawset(o, k, v)
+  end
+end
+
+function mat3:__string()
+  base = "[" 
+  for i=0,8,1 do
+    if i > 0 and i % 3 == 0 
+      then base = base .. "|" .. self[i] .. " "
+      else base = base .. self[i] .. " "
+    end
+  end
+  return base .. "]"
+end
+
+function mat3.new(x)
+  local buf = RM.alloc(4 * 9) 
+  if x == nil then 
+    -- if no args initialize to identity matrix
+    M.identityMat3(buf)
+  else
+    -- otherwise copy from nested lists, ew
+    for row=1,3,1 do
+      for col=1,3,1 do
+        buf:setFloat((row-1)*3 + (col-1), x[row][col])
+      end
+    end
+  end
+  return setmetatable({buf = buf}, mat3)
+end
+
+function mat3:add(other)
+  M.addMat3(self.buf, other.buf)
+end
+
+function mat3:mul(other)
+  M.mulMat3(self.buf, other.buf)
+end
+
+function mat3:apply(v3)
+  M.applyMat3(self.buf, v3.buf)
+end
+
+function mat3:get(col, row) 
+  return self[(row * 3) + col]
+end
+
+function mat3:copy(from)
+  M.copyMat3(self.buf, from.buf)
+end
+
+function mat3:equal(other)
+  for i=0,8,1 do
+    if math.abs(self[i] - other[i]) > 0.0001 then return false end
+  end
+  return true
+end
+
+return mat3

--- a/script/math/vec2.lua
+++ b/script/math/vec2.lua
@@ -26,7 +26,7 @@ function vec2.__newindex(o, k, v)
   end
 end
 
-function vec2:__string()
+function vec2:__tostring()
   return "[" .. self.x .. "," .. self.y .. "]"
 end
 

--- a/script/math/vec2.lua
+++ b/script/math/vec2.lua
@@ -49,7 +49,7 @@ function vec2.__mul(a, s)
 end
 
 function vec2.new(x,y)
-  local buf = RM.alloc(4 * 2)  
+  local buf = RM.gcAlloc(4 * 2)  
   local o = {buf = buf}
   setmetatable(o, vec2)
   o.x = x

--- a/script/math/vec2.lua
+++ b/script/math/vec2.lua
@@ -97,6 +97,10 @@ function vec2:scale(s)
   M.scaleVec2(self.buf, s)
 end
 
+function vec2:normalize()
+  M.normalizeVec2(self.buf)
+end
+
 function feq(a, b)
   return math.abs(a-b) < 0.00001
 end

--- a/script/math/vec2.lua
+++ b/script/math/vec2.lua
@@ -26,6 +26,10 @@ function vec2.__newindex(o, k, v)
   end
 end
 
+function vec2:__eq(other)
+  return M.floatCmp(self.x, other.x) and M.floatCmp(self.y, other.y)
+end
+
 function vec2:__tostring()
   return "[" .. self.x .. "," .. self.y .. "]"
 end
@@ -99,14 +103,6 @@ end
 
 function vec2:normalize()
   M.normalizeVec2(self.buf)
-end
-
-function feq(a, b)
-  return math.abs(a-b) < 0.00001
-end
-
-function vec2:equal(other)
-  return feq(self.x, other.x) and feq(self.y, other.y) 
 end
 
 return vec2

--- a/script/math/vec2.lua
+++ b/script/math/vec2.lua
@@ -1,0 +1,108 @@
+local M = MATH_C_LIB
+
+local vec2 = {}
+
+function vec2.__index(o, k)
+  if k == "x" then
+    local buf = rawget(o, "buf")
+    return buf:getFloat(0)
+  elseif k == "y" then
+    local buf = rawget(o, "buf")
+    return buf:getFloat(1)
+  else
+    return vec2[k]
+  end
+end
+
+function vec2.__newindex(o, k, v)
+  if k == "x" then
+    local b = rawget(o, "buf")
+    b:setFloat(0, v)
+  elseif k == "y" then
+    local b = rawget(o, "buf")
+    b:setFloat(1, v)
+  else
+    rawset(o, k, v)
+  end
+end
+
+function vec2:__string()
+  return "[" .. self.x .. "," .. self.y .. "]"
+end
+
+function vec2.__add(a, b)
+  local n = vec2.from(a)
+  n:add(b)
+  return n
+end
+
+function vec2.__sub(a, b)
+  local n = vec2.from(a)
+  n:sub(b)
+  return n
+end
+
+function vec2.__mul(a, s)
+  local n = vec2.from(a)
+  n:scale(s)
+  return n
+end
+
+function vec2.new(x,y)
+  local buf = RM.alloc(4 * 2)  
+  local o = {buf = buf}
+  setmetatable(o, vec2)
+  o.x = x
+  o.y = y
+  return o
+end
+
+function vec2.from(other)
+  local n = vec2.new(0, 0)
+  n:copy(other)
+  return n
+end
+
+function vec2:add(other)
+  M.addVec2(self.buf, other.buf)
+end
+
+function vec2:sub(other)
+  M.subVec2(self.buf, other.buf)
+end
+
+function vec2:copy(from)
+  M.copyVec2(self.buf, from.buf)
+end
+
+function vec2:length()
+  return M.lenVec2(self.buf)
+end
+
+function vec2:dot(other)
+  return M.dotVec2(self.buf, other.buf)
+end
+
+function vec2:rotate(theta)
+  M.rotateVec2(self.buf, theta)
+end
+
+function vec2:copyRotate(theta)
+  local n = vec2.from(self)
+  n:rotate(theta)
+  return n
+end
+
+function vec2:scale(s)
+  M.scaleVec2(self.buf, s)
+end
+
+function feq(a, b)
+  return math.abs(a-b) < 0.00001
+end
+
+function vec2:equal(other)
+  return feq(self.x, other.x) and feq(self.y, other.y) 
+end
+
+return vec2

--- a/script/math/vec3.lua
+++ b/script/math/vec3.lua
@@ -94,6 +94,10 @@ function vec3:scale(s)
   M.scaleVec3(self.buf, s)
 end
 
+function vec3:normalize()
+  M.normalizeVec2(self.buf)
+end
+
 function feq(a, b)
   return math.abs(a-b) < 0.00001
 end

--- a/script/math/vec3.lua
+++ b/script/math/vec3.lua
@@ -100,7 +100,7 @@ function vec3:scale(s)
 end
 
 function vec3:normalize()
-  M.normalizeVec2(self.buf)
+  M.normalizeVec3(self.buf)
 end
 
 return vec3

--- a/script/math/vec3.lua
+++ b/script/math/vec3.lua
@@ -32,6 +32,11 @@ function vec3.__newindex(o, k, v)
   end
 end
 
+function vec3:__eq(other)
+  return M.floatCmp(self.x, other.x) and M.floatCmp(self.y, other.y) and M.floatCmp(self.z, other.z)
+end
+
+
 function vec3:__tostring()
   return "[" .. self.x .. "," .. self.y .. "," .. self.z .. "]"
 end
@@ -97,14 +102,5 @@ end
 function vec3:normalize()
   M.normalizeVec2(self.buf)
 end
-
-function feq(a, b)
-  return math.abs(a-b) < 0.00001
-end
-
-function vec3:equal(other)
-  return feq(self.x, other.x) and feq(self.y, other.y) and feq(self.z, other.z)
-end
-
 
 return vec3

--- a/script/math/vec3.lua
+++ b/script/math/vec3.lua
@@ -32,7 +32,7 @@ function vec3.__newindex(o, k, v)
   end
 end
 
-function vec3:__string()
+function vec3:__tostring()
   return "[" .. self.x .. "," .. self.y .. "," .. self.z .. "]"
 end
 

--- a/script/math/vec3.lua
+++ b/script/math/vec3.lua
@@ -55,7 +55,7 @@ function vec3.__mul(a, s)
 end
 
 function vec3.new(x,y, z)
-  local buf = RM.alloc(4 * 3)  
+  local buf = RM.gcAlloc(4 * 3)  
   local o = {buf = buf}
   setmetatable(o, vec3)
   o.x = x

--- a/script/math/vec3.lua
+++ b/script/math/vec3.lua
@@ -1,0 +1,106 @@
+local vec3 = {}
+local M = MATH_C_LIB
+
+
+function vec3.__index(o, k)
+  if k == "x" then
+    local buf = rawget(o, "buf")
+    return buf:getFloat(0)
+  elseif k == "y" then
+    local buf = rawget(o, "buf")
+    return buf:getFloat(1)
+  elseif k == "z" then
+    local buf = rawget(o, "buf")
+    return buf:getFloat(2)
+  else
+    return vec3[k]
+  end
+end
+
+function vec3.__newindex(o, k, v)
+  if k == "x" then
+    local b = rawget(o, "buf")
+    b:setFloat(0, v)
+  elseif k == "y" then
+    local b = rawget(o, "buf")
+    b:setFloat(1, v)
+  elseif k == "z" then
+    local b = rawget(o, "buf")
+    b:setFloat(2, v)
+  else
+    rawset(o, k, v)
+  end
+end
+
+function vec3:__string()
+  return "[" .. self.x .. "," .. self.y .. "," .. self.z .. "]"
+end
+
+function vec3.__add(a, b)
+  local n = vec3.from(a)
+  n:add(b)
+  return n
+end
+
+function vec3.__sub(a, b)
+  local n = vec3.from(a)
+  n:sub(b)
+  return n
+end
+
+function vec3.__mul(a, s)
+  local n = vec3.from(a)
+  n:scale(s)
+  return n
+end
+
+function vec3.new(x,y, z)
+  local buf = RM.alloc(4 * 3)  
+  local o = {buf = buf}
+  setmetatable(o, vec3)
+  o.x = x
+  o.y = y
+  o.z = z
+  return o
+end
+
+function vec3.from(other)
+  local n = vec3.new(0, 0)
+  n:copy(other)
+  return n
+end
+
+function vec3:add(other)
+  M.addVec3(self.buf, other.buf)
+end
+
+function vec3:sub(other)
+  M.subVec3(self.buf, other.buf)
+end
+
+function vec3:copy(from)
+  M.copyVec3(self.buf, from.buf)
+end
+
+function vec3:length()
+  return M.lenVec3(self.buf)
+end
+
+function vec3:dot(other)
+  return M.dotVec3(self.buf, other.buf)
+end
+
+function vec3:scale(s)
+  M.scaleVec3(self.buf, s)
+end
+
+function feq(a, b)
+  return math.abs(a-b) < 0.00001
+end
+
+function vec3:equal(other)
+  return feq(self.x, other.x) and feq(self.y, other.y) and feq(self.z, other.z)
+end
+
+
+return vec3

--- a/script/ps2math.lua
+++ b/script/ps2math.lua
@@ -1,0 +1,15 @@
+
+local types = {
+  vec2_mt = require("math.vec2"),
+  vec3_mt = require("math.vec3"),
+  mat3_mt = require("math.mat3"),
+}
+
+types.vec2 = types.vec2_mt.new
+types.vec2From = types.vec2_mt.from
+types.vec3 = types.vec3_mt.new
+types.vec3From = types.vec3_mt.from
+types.mat3 = types.mat3_mt.new
+
+return types
+

--- a/script/ps2math.lua
+++ b/script/ps2math.lua
@@ -11,5 +11,11 @@ types.vec3 = types.vec3_mt.new
 types.vec3From = types.vec3_mt.from
 types.mat3 = types.mat3_mt.new
 
+local EPSILON = 0.0001
+
+function types.floatCmp(a, b)
+  return math.abs(a-b) < EPSILON
+end
+
 return types
 

--- a/script/test.lua
+++ b/script/test.lua
@@ -1,0 +1,25 @@
+
+local test = {}
+
+function test.handler(err)
+  LOG.error("TEST FAILED: " .. err)
+end
+
+function test.run_suite(name, t)
+  local ran = 0
+  local pass = 0
+  LOG.info("Running suite " .. name)
+  for name,fn in pairs(t) do
+    if type(fn) == "function" then 
+      ran = ran + 1
+      local rv = xpcall(fn, test.handler)
+      if rv then pass = pass + 1 end
+    end
+  end
+  local st = "PASS"
+  if pass < ran then st = "FAIL" end
+  LOG.info(" === " .. st .. " " .. name)
+  LOG.info( " @ " .. tostring(pass) .. " / " .. tostring(ran))
+end
+
+return test

--- a/script/test.lua
+++ b/script/test.lua
@@ -20,6 +20,7 @@ function test.run_suite(name, t)
   if pass < ran then st = "FAIL" end
   LOG.info(" === " .. st .. " " .. name)
   LOG.info( " @ " .. tostring(pass) .. " / " .. tostring(ran))
+  return pass == ran
 end
 
 return test

--- a/script/test.lua
+++ b/script/test.lua
@@ -1,8 +1,10 @@
 
 local test = {}
 
-function test.handler(err)
-  LOG.error("TEST FAILED: " .. err)
+function test.handler(testName)
+  return function(err)
+    LOG.error(" % Failed Test (" .. testName .. ") :: " .. err)
+  end
 end
 
 function test.run_suite(name, t)
@@ -12,7 +14,7 @@ function test.run_suite(name, t)
   for name,fn in pairs(t) do
     if type(fn) == "function" then 
       ran = ran + 1
-      local rv = xpcall(fn, test.handler)
+      local rv = xpcall(fn, test.handler(name))
       if rv then pass = pass + 1 end
     end
   end
@@ -22,5 +24,12 @@ function test.run_suite(name, t)
   LOG.info( " @ " .. tostring(pass) .. " / " .. tostring(ran))
   return pass == ran
 end
+
+function test.equal(exp, actual)
+  if (exp == actual) == false then
+    error("expected: " .. tostring(exp) .. ", actual: " .. tostring(actual))
+  end
+end
+
 
 return test

--- a/script/test/test_mat3x3.lua
+++ b/script/test/test_mat3x3.lua
@@ -6,10 +6,10 @@ local t = {}
 
 function t.mat3_init()
   local a = M.mat3()
-  assert(a[0] == 1)
-  assert(a[1] == 0)
-  assert(a[3] == 0)
-  assert(a[4] == 1)
+  test.equal(a[0], 1)
+  test.equal(a[1], 0)
+  test.equal(a[3], 0)
+  test.equal(a[4], 1)
 end
 
 function t.mat3_add()
@@ -17,7 +17,7 @@ function t.mat3_add()
   local b = M.mat3({ {1,2,3},{0,0,0},{0,0,0} })
   a:add(b)
   local c = M.mat3({ {2,2,3},{0,1,0},{0,0,1} })
-  assert(a:equal(c))
+  test.equal(a, c)
 end
 
 function t.mat3_multiply_identity()
@@ -26,15 +26,15 @@ function t.mat3_multiply_identity()
   local x = M.mat3()
   x:copy(a)
   x:mul(ii)
-  assert(a:equal(x))
+  test.equal(a, x)
 end
 
 function t.test_mat3_multiply()
   local ta = M.mat3({ {5,12,9},{2,4.2,1},{11,8,0.2} })
   local tb = M.mat3({ {7,12,122},{0.1,17,8},{5,100,-2} })
-  local tres = M.mat3({ {81.2,1164,688},{19.42,195.4,275.6},{78.8,288,1405.6} })
+  local tres = M.mat3({ {81.2,1164,688},{19.419998,195.4,275.599976},{78.799995,288,1405.6} })
   ta:mul(tb)
-  assert(ta:equal(tres))
+  test.equal(ta, tres)
 end
 
 function t.test_mat3_apply_identity()
@@ -42,15 +42,15 @@ function t.test_mat3_apply_identity()
   local va = M.vec3(5,12,7.4)
   local vb = M.vec3From(va)
   ii:apply(va)
-  assert(va:equal(vb))
+  test.equal(va, vb)
 end
 
 function t.test_mat3_apply_rotate()
   local ra = M.vec3(12, 8, 1)
-  local rx = M.vec3(10.17144 + 10, 10.22456 + 4, 1)
+  local rx = M.vec3(10.17144429 + 10, 10.2245646 + 4, 1)
   local rm = M.mat3({ {math.cos(0.2), -1 * math.sin(0.2), 10}, {math.sin(0.2), math.cos(0.2), 4}, {0,0,1} })
   rm:apply(ra)
-  assert(ra:equal(rx))
+  test.equal(ra, rx)
 end
 
 return function() return test.run_suite("3x3 Matrix", t) end

--- a/script/test/test_mat3x3.lua
+++ b/script/test/test_mat3x3.lua
@@ -1,0 +1,58 @@
+
+local M = require("ps2math")
+local test = require("test")
+
+local t = {}
+
+function t.mat3_init()
+  local a = M.mat3()
+  assert(a[0] == 1)
+  assert(a[1] == 0)
+  assert(a[3] == 0)
+  assert(a[4] == 1)
+end
+
+function t.mat3_add()
+  local a = M.mat3()
+  local b = M.mat3({ {1,2,3},{0,0,0},{0,0,0} })
+  M.mat3_mt.add(a, b)
+  local c = M.mat3({ {2,2,3},{0,1,0},{0,0,1} })
+  assert(a:equal(c))
+end
+
+function t.mat3_multiply_identity()
+  local ii = M.mat3()
+  local a = M.mat3({ {1,2,3},{0,0,0},{0,0,0} })
+  local x = M.mat3()
+  x:copy(a)
+  x:mul(ii)
+  assert(a:equal(x))
+end
+
+function t.test_mat3_multiply()
+  local ta = M.mat3({ {5,12,9},{2,4.2,1},{11,8,0.2} })
+  local tb = M.mat3({ {7,12,122},{0.1,17,8},{5,100,-2} })
+  local tres = M.mat3({ {81.2,1164,688},{19.42,195.4,275.6},{78.8,288,1405.6} })
+  ta:mul(tb)
+  assert(ta:equal(tres))
+end
+
+function t.test_mat3_apply_identity()
+  local ii = M.mat3()
+  local va = M.vec3(5,12,7.4)
+  local vb = M.vec3From(va)
+  ii:apply(va)
+  assert(va:equal(vb))
+end
+
+function t.test_mat3_apply_rotate()
+  local ra = M.vec3(12, 8, 1)
+  local rx = M.vec3(10.17144 + 10, 10.22456 + 4, 1)
+  local rm = M.mat3({ {math.cos(0.2), -1 * math.sin(0.2), 10}, {math.sin(0.2), math.cos(0.2), 4}, {0,0,1} })
+  rm:apply(ra)
+  assert(ra:equal(rx))
+end
+
+return function() test.run_suite("3x3 Matrix", t) end
+
+

--- a/script/test/test_mat3x3.lua
+++ b/script/test/test_mat3x3.lua
@@ -15,7 +15,7 @@ end
 function t.mat3_add()
   local a = M.mat3()
   local b = M.mat3({ {1,2,3},{0,0,0},{0,0,0} })
-  M.mat3_mt.add(a, b)
+  a:add(b)
   local c = M.mat3({ {2,2,3},{0,1,0},{0,0,1} })
   assert(a:equal(c))
 end

--- a/script/test/test_mat3x3.lua
+++ b/script/test/test_mat3x3.lua
@@ -53,6 +53,6 @@ function t.test_mat3_apply_rotate()
   assert(ra:equal(rx))
 end
 
-return function() test.run_suite("3x3 Matrix", t) end
+return function() return test.run_suite("3x3 Matrix", t) end
 
 

--- a/script/test/test_vec2.lua
+++ b/script/test/test_vec2.lua
@@ -26,6 +26,25 @@ function suite.vec2_add()
   assert(v3.y == 97)
 end
 
+function suite.vec2_sub()
+  local v1 = M.vec2(10, 32)
+  local v2 = M.vec2(7, 12)
+  local v3 = v1 - v2
+  assert(v3.x == 3)
+  assert(v3.y == 20)
+end
+
+function suite.vec2_length()
+  assert(M.vec2(0,0):length() == 0)
+  assert(M.vec2(1, 0):length() == 1)
+  assert(M.vec2(3, 4):length() == 5)
+end
+
+function suite.vec2_dot()
+  local d1 = M.vec2(0,0):dot(M.vec2(7, 19))
+  assert(d1 == 0)
+end
+
 function suite.vec2_scale()
   local v = M.vec2(4, 7)
   local n = v * 5
@@ -34,4 +53,4 @@ function suite.vec2_scale()
 end
 
 
-return function() test.run_suite(suite.name, suite) end
+return function() return test.run_suite(suite.name, suite) end

--- a/script/test/test_vec2.lua
+++ b/script/test/test_vec2.lua
@@ -1,0 +1,30 @@
+
+local M = require("ps2math")
+local test = require("test")
+local suite = {name = "Vector 2D"}
+
+function suite.vec2_init()
+  local v = M.vec2(5, 17)
+  assert(v.buf:getFloat(0) == 5)
+  assert(v.buf:getFloat(1) == 17)
+  assert(v.x == 5)
+  assert(v.y == 17)
+end
+
+function suite.vec2_copy()
+  local v = M.vec2(111, 222)
+  local other = M.vec2From(v)
+  assert(v.x == other.x)
+  assert(v.y == other.y)
+end
+
+function suite.vec2_add()
+  local v1 = M.vec2(0, 77)
+  local v2 = M.vec2(10, 20)
+  local v3 = v1 + v2
+  assert(v3.x == 10)
+  assert(v3.y == 97)
+end
+
+
+return function() test.run_suite(suite.name, suite) end

--- a/script/test/test_vec2.lua
+++ b/script/test/test_vec2.lua
@@ -26,5 +26,12 @@ function suite.vec2_add()
   assert(v3.y == 97)
 end
 
+function suite.vec2_scale()
+  local v = M.vec2(4, 7)
+  local n = v * 5
+  assert(n.x == 20)
+  assert(n.y == 35)
+end
+
 
 return function() test.run_suite(suite.name, suite) end

--- a/script/test/test_vec2.lua
+++ b/script/test/test_vec2.lua
@@ -5,52 +5,54 @@ local suite = {name = "Vector 2D"}
 
 function suite.vec2_init()
   local v = M.vec2(5, 17)
-  assert(v.buf:getFloat(0) == 5)
-  assert(v.buf:getFloat(1) == 17)
-  assert(v.x == 5)
-  assert(v.y == 17)
+  test.equal(v.buf:getFloat(0), 5)
+  test.equal(v.buf:getFloat(1), 17)
+  test.equal(v.x, 5)
+  test.equal(v.y, 17)
 end
 
 function suite.vec2_copy()
   local v = M.vec2(111, 222)
   local other = M.vec2From(v)
-  assert(v.x == other.x)
-  assert(v.y == other.y)
+  test.equal(v.x, other.x)
+  test.equal(v.y, other.y)
 end
 
 function suite.vec2_add()
   local v1 = M.vec2(0, 77)
   local v2 = M.vec2(10, 20)
   local v3 = v1 + v2
-  assert(v3.x == 10)
-  assert(v3.y == 97)
+  test.equal(v3, M.vec2(10, 97))
 end
 
 function suite.vec2_sub()
   local v1 = M.vec2(10, 32)
   local v2 = M.vec2(7, 12)
   local v3 = v1 - v2
-  assert(v3.x == 3)
-  assert(v3.y == 20)
+  test.equal(v3, M.vec2(3, 20))
 end
 
 function suite.vec2_length()
-  assert(M.vec2(0,0):length() == 0)
-  assert(M.vec2(1, 0):length() == 1)
-  assert(M.vec2(3, 4):length() == 5)
+  test.equal(M.vec2(0,0):length(), 0)
+  test.equal(M.vec2(1, 0):length(), 1)
+  test.equal(M.vec2(3, 4):length(), 5)
 end
 
 function suite.vec2_dot()
   local d1 = M.vec2(0,0):dot(M.vec2(7, 19))
-  assert(d1 == 0)
+  test.equal(d1, 0)
 end
 
 function suite.vec2_scale()
   local v = M.vec2(4, 7)
   local n = v * 5
-  assert(n.x == 20)
-  assert(n.y == 35)
+  test.equal(n, M.vec2(20, 35))
 end
 
+function suite.vec2_normalize()
+  local v = M.vec2(10, 7)
+  v:normalize()
+  test.equal(v, M.vec2(0.819232, 0.5734623))
+end
 
 return function() return test.run_suite(suite.name, suite) end

--- a/script/test/test_vec3.lua
+++ b/script/test/test_vec3.lua
@@ -1,0 +1,61 @@
+
+local M = require("ps2math")
+local test = require("test")
+local suite = {name = "Vector 3D"}
+
+function suite.vec3_init()
+  local v = M.vec3(5, 17, 9)
+  test.equal(v.buf:getFloat(0), 5)
+  test.equal(v.buf:getFloat(1), 17)
+  test.equal(v.buf:getFloat(2), 9)
+  test.equal(v.x, 5)
+  test.equal(v.y, 17)
+  test.equal(v.z, 9)
+end
+
+function suite.vec3_copy()
+  local v = M.vec3(111, 222, 333)
+  local other = M.vec3From(v)
+  test.equal(v.x, other.x)
+  test.equal(v.y, other.y)
+  test.equal(v.z, other.z)
+end
+
+function suite.vec3_add()
+  local v1 = M.vec3(0, 77, 100)
+  local v2 = M.vec3(10, 20, 30)
+  local v3 = v1 + v2
+  test.equal(v3, M.vec3(10, 97, 130))
+end
+
+function suite.vec3_sub()
+  local v1 = M.vec3(10, 32, 11)
+  local v2 = M.vec3(7, 12, 19)
+  local v3 = v1 - v2
+  test.equal(v3, M.vec3(3, 20, -8))
+end
+
+function suite.vec3_length()
+  test.equal(M.vec3(0,0, 0):length(), 0)
+  test.equal(M.vec3(1, 0, 0):length(), 1)
+  test.equal(M.vec3(3, 4, 8):length(), math.sqrt(89))
+end
+
+function suite.vec3_dot()
+  local d1 = M.vec3(0,0,0):dot(M.vec3(7, 19, 99))
+  test.equal(d1, 0)
+end
+
+function suite.vec3_scale()
+  local v = M.vec3(4, 7, 11)
+  local n = v * 5
+  test.equal(n, M.vec3(20, 35, 55))
+end
+
+function suite.vec3_normalize()
+  local v = M.vec3(10, 7, 1)
+  v:normalize()
+  test.equal(v, M.vec3(10 / math.sqrt(150), 7 / math.sqrt(150), 1 / math.sqrt(150)))
+end
+
+return function() return test.run_suite(suite.name, suite) end

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ PS2SDK=/usr/local/ps2dev/ps2sdk
 MAIN_OBJ=main.o utils.o 
 LUA_OBJ=gslua.o dmalua.o bufferlua.o tga.o padlua.o drawlua.o loglua.o ps2luaprog.o 
 DRAW_OBJ=draw/draw2d.o draw/buffer.o
-MATH_OBJ=ps2math.o math/vec2lua.o math/vec3lua.o math/mat3lua.o
+MATH_OBJ=ps2math.o math/vec2lua.o math/vec3lua.o math/mat3lua.o math/float.o
 
 EE_BIN=test.elf
 EE_OBJS= $(MAIN_OBJ) $(LUA_OBJ) $(DRAW_OBJ) $(MATH_OBJ)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,12 @@
 PS2SDK=/usr/local/ps2dev/ps2sdk
 
-MAIN_OBJ=main.o utils.o
-LUA_OBJ=gslua.o dmalua.o bufferlua.o tga.o padlua.o drawlua.o loglua.o ps2luaprog.o
+MAIN_OBJ=main.o utils.o 
+LUA_OBJ=gslua.o dmalua.o bufferlua.o tga.o padlua.o drawlua.o loglua.o ps2luaprog.o 
 DRAW_OBJ=draw/draw2d.o draw/buffer.o
+MATH_OBJ=ps2math.o math/vec2lua.o math/vec3lua.o math/mat3lua.o
 
 EE_BIN=test.elf
-EE_OBJS= $(MAIN_OBJ) $(LUA_OBJ) $(DRAW_OBJ)
+EE_OBJS= $(MAIN_OBJ) $(LUA_OBJ) $(DRAW_OBJ) $(MATH_OBJ)
 EE_LIBS=-ldma -lgraph -ldraw -lkernel -ldebug -lmath3d -lm -lpad -llua
 EE_CFLAGS+=-Wall --std=c99 -Wno-sign-compare -fno-strict-aliasing -fno-exceptions -DLUA_USE_PS2 -DLOG_TRACE
 

--- a/src/bufferlua.c
+++ b/src/bufferlua.c
@@ -186,6 +186,26 @@ static int buffer_read(lua_State *l) {
   return 1;
 }
 
+static int buffer_getfloat(lua_State *l) {
+  int index = lua_tointeger(l, 2);
+  lua_pushstring(l, "ptr");
+  lua_gettable(l, 1);
+  float *ptr = (float*) lua_touserdata(l, -1);
+  float res = ptr[index];
+  lua_pushnumber(l, res);
+  return 1;
+}
+
+static int buffer_setfloat(lua_State *l) {
+  int index = lua_tointeger(l, 2);
+  lua_pushstring(l, "ptr");
+  lua_gettable(l, 1);
+  float *ptr = (float*) lua_touserdata(l, -1);
+  float value = lua_tonumber(l, 3);
+  ptr[index] = value;
+  return 0;
+}
+
 static int buffer_write(lua_State *l) {
   int index = lua_tointeger(l, 2);
   if (index % 4 != 0) {
@@ -259,6 +279,11 @@ int drawlua_init(lua_State *l) {
   lua_setfield(l, -2, "read");
   lua_pushcfunction(l, buffer_write);
   lua_setfield(l, -2, "write");
+  lua_pushcfunction(l, buffer_getfloat);
+  lua_setfield(l, -2, "getFloat");
+  lua_pushcfunction(l, buffer_setfloat);
+  lua_setfield(l, -2, "setFloat");
+  
   lua_setfield(l, -2, "__index");
   lua_pop(l, 1);
 

--- a/src/bufferlua.c
+++ b/src/bufferlua.c
@@ -190,7 +190,7 @@ static int buffer_getfloat(lua_State *l) {
   int index = lua_tointeger(l, 2);
   lua_pushstring(l, "ptr");
   lua_gettable(l, 1);
-  float *ptr = (float*) lua_touserdata(l, -1);
+  float *ptr = (float *)lua_touserdata(l, -1);
   float res = ptr[index];
   lua_pushnumber(l, res);
   return 1;
@@ -200,7 +200,7 @@ static int buffer_setfloat(lua_State *l) {
   int index = lua_tointeger(l, 2);
   lua_pushstring(l, "ptr");
   lua_gettable(l, 1);
-  float *ptr = (float*) lua_touserdata(l, -1);
+  float *ptr = (float *)lua_touserdata(l, -1);
   float value = lua_tonumber(l, 3);
   ptr[index] = value;
   return 0;
@@ -283,7 +283,7 @@ int drawlua_init(lua_State *l) {
   lua_setfield(l, -2, "getFloat");
   lua_pushcfunction(l, buffer_setfloat);
   lua_setfield(l, -2, "setFloat");
-  
+
   lua_setfield(l, -2, "__index");
   lua_pop(l, 1);
 

--- a/src/bufferlua.c
+++ b/src/bufferlua.c
@@ -305,7 +305,7 @@ int drawlua_init(lua_State *l) {
   lua_pushcfunction(l, buffer_alloc);
   lua_setfield(l, -2, "alloc");
   lua_pushcfunction(l, buffer_gcalloc);
-  lua_setfield(l, -2 ,"gcAlloc");
+  lua_setfield(l, -2, "gcAlloc");
   lua_setglobal(l, "RM");
 
   return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -168,6 +168,12 @@ int main(int argc, char *argv[]) {
   draw2d_lua_init(L);
   loglua_init(L);
 
+  lua_createtable(L, 0, 20);
+  lua_setglobal(L, "MATH_C_LIB");
+  vec2lua_init(L);
+  vec3lua_init(L);
+  mat3lua_init(L);
+
   // TODO(Tom Marks): better abstraction for drawlua_*
   drawlua_init(L);
 

--- a/src/main.c
+++ b/src/main.c
@@ -173,6 +173,7 @@ int main(int argc, char *argv[]) {
   vec2lua_init(L);
   vec3lua_init(L);
   mat3lua_init(L);
+  floatmath_init(L);
 
   // TODO(Tom Marks): better abstraction for drawlua_*
   drawlua_init(L);

--- a/src/math/float.c
+++ b/src/math/float.c
@@ -1,0 +1,22 @@
+#include <math.h>
+#include <lua.h>
+
+#include "log.h"
+
+#define EPSILON 0.000001
+
+static int float_compare(lua_State *l) {
+  float a = lua_tonumber(l, 1);
+  float b = lua_tonumber(l, 2);
+  int res = fabs(a-b) < EPSILON;
+  lua_pushboolean(l, res);
+  return 1;
+}
+
+int floatmath_init(lua_State *l) {
+  lua_getglobal(l, "MATH_C_LIB");
+  lua_pushcfunction(l, float_compare);
+  lua_setfield(l, -2, "floatCmp");
+  lua_pop(l, 1);
+  return 0;
+}

--- a/src/math/mat3lua.c
+++ b/src/math/mat3lua.c
@@ -1,0 +1,72 @@
+#include <lua.h>
+
+#include "ps2math.h"
+#include "log.h"
+
+#define buffer_null_check(p, s) \
+  do{ if(!p) { lua_pushstring(l, "got null buffer for " s); \
+                lua_error(l); return 1; } }while(0)
+
+#define get_buf(i, to, msg) \
+  lua_pushstring(l, "ptr"); \
+  lua_gettable(l, i); \
+  float *to = lua_touserdata(l, -1); \
+  buffer_null_check(to, msg " [" #i "]"); \
+  ((void)0)
+
+
+static int lua_add_mat3(lua_State *l) {
+  get_buf(1, buf1, "add m3");
+  get_buf(2, buf2, "add m3");
+
+  p2m_m3_add(buf1, buf2);
+
+  return 0;
+}
+
+
+// local c = copy(to, from)
+static int lua_copy_mat3(lua_State *l) {
+  get_buf(1, buf1, "copy m3");
+  get_buf(2, buf2, "copy m3");
+
+  p2m_m3_copy(buf1, buf2);
+
+  return 0;
+}
+
+static int lua_identity_mat3(lua_State *l) {
+  get_buf(1, buf1, "idetity m3");
+  p2m_m3_identity(buf1);
+  return 0;
+}
+
+static int lua_multiply_mat3(lua_State *l) {
+  get_buf(1, buf1, "mul m3");
+  get_buf(2, buf2, "mul m3");
+  p2m_m3_multiply(buf1, buf2, buf1);
+  return 0;
+}
+
+static int lua_apply_mat3(lua_State *l) {
+  get_buf(1, buf1, "apply m3");
+  get_buf(2, buf2, "apply m3 (v3)");
+  p2m_m3_apply(buf1, buf2);
+  return 0;
+}
+
+int mat3lua_init(lua_State *l) {
+  lua_getglobal(l, "MATH_C_LIB");
+  lua_pushcfunction(l, lua_add_mat3);
+  lua_setfield(l, -2, "addMat3");
+  lua_pushcfunction(l, lua_copy_mat3);
+  lua_setfield(l, -2, "copyMat3");
+  lua_pushcfunction(l, lua_identity_mat3);
+  lua_setfield(l, -2, "identityMat3");
+  lua_pushcfunction(l, lua_multiply_mat3);
+  lua_setfield(l, -2, "mulMat3");
+  lua_pushcfunction(l, lua_apply_mat3);
+  lua_setfield(l, -2, "applyMat3");
+  lua_pop(l, 1);
+  return 0;
+}

--- a/src/math/mat3lua.c
+++ b/src/math/mat3lua.c
@@ -4,7 +4,7 @@
 #include "log.h"
 
 #define buffer_null_check(p, s) \
-  do{ if(!p) { lua_pushstring(l, "got null buffer for " s); \
+  do { if (!p) { lua_pushstring(l, "got null buffer for " s); \
                 lua_error(l); return 1; } }while(0)
 
 #define get_buf(i, to, msg) \

--- a/src/math/vec2lua.c
+++ b/src/math/vec2lua.c
@@ -4,7 +4,7 @@
 #include "log.h"
 
 #define buffer_null_check(p, s) \
-  do{ if(!p) { lua_pushstring(l, "got null buffer for " s); \
+  do { if (!p) { lua_pushstring(l, "got null buffer for " s); \
                 lua_error(l); return 1; } }while(0)
 
 #define get_buf(i, to, msg) \
@@ -19,7 +19,7 @@ static int lua_add_vec2(lua_State *l) {
   get_buf(1, buf1, "copy vec");
   get_buf(2, buf2, "copy vec");
 
-  buf1[0] += buf2[0]; 
+  buf1[0] += buf2[0];
   buf1[1] += buf2[1];
 
   return 0;
@@ -29,7 +29,7 @@ static int lua_sub_vec2(lua_State *l) {
   get_buf(1, buf1, "sub vec");
   get_buf(2, buf2, "sub vec");
 
-  buf1[0] -= buf2[0]; 
+  buf1[0] -= buf2[0];
   buf1[1] -= buf2[1];
 
   return 0;
@@ -40,7 +40,7 @@ static int lua_copy_vec2(lua_State *l) {
   get_buf(1, buf1, "copy vec");
   get_buf(2, buf2, "copy vec");
 
-  buf1[0] = buf2[0]; 
+  buf1[0] = buf2[0];
   buf1[1] = buf2[1];
 
   return 0;

--- a/src/math/vec2lua.c
+++ b/src/math/vec2lua.c
@@ -53,6 +53,14 @@ static int lua_length_vec2(lua_State *l) {
   return 1;
 }
 
+static int lua_normalize_vec2(lua_State *l) {
+  get_buf(1, buf1, "normalize vec2");
+  float len = p2m_vec2_length(buf1);
+  buf1[0] /= len;
+  buf1[1] /= len;
+  return 0;
+}
+
 static int lua_dot_vec2(lua_State *l) {
   get_buf(1, buf1, "dot vec2");
   get_buf(2, buf2, "dot vec2");
@@ -85,6 +93,8 @@ int vec2lua_init(lua_State *l) {
   lua_setfield(l, -2, "copyVec2");
   lua_pushcfunction(l, lua_length_vec2);
   lua_setfield(l, -2, "lenVec2");
+  lua_pushcfunction(l, lua_normalize_vec2);
+  lua_setfield(l, -2, "normalizeVec2");
   lua_pushcfunction(l, lua_dot_vec2);
   lua_setfield(l, -2, "dotVec2");
   lua_pushcfunction(l, lua_rotate_vec2);

--- a/src/math/vec2lua.c
+++ b/src/math/vec2lua.c
@@ -1,0 +1,96 @@
+#include <lua.h>
+
+#include "ps2math.h"
+#include "log.h"
+
+#define buffer_null_check(p, s) \
+  do{ if(!p) { lua_pushstring(l, "got null buffer for " s); \
+                lua_error(l); return 1; } }while(0)
+
+#define get_buf(i, to, msg) \
+  lua_pushstring(l, "ptr"); \
+  lua_gettable(l, i); \
+  float *to = lua_touserdata(l, -1); \
+  buffer_null_check(to, msg " [" #i "]"); \
+  ((void)0)
+
+
+static int lua_add_vec2(lua_State *l) {
+  get_buf(1, buf1, "copy vec");
+  get_buf(2, buf2, "copy vec");
+
+  buf1[0] += buf2[0]; 
+  buf1[1] += buf2[1];
+
+  return 0;
+}
+
+static int lua_sub_vec2(lua_State *l) {
+  get_buf(1, buf1, "sub vec");
+  get_buf(2, buf2, "sub vec");
+
+  buf1[0] -= buf2[0]; 
+  buf1[1] -= buf2[1];
+
+  return 0;
+}
+
+// local c = copy(to, from)
+static int lua_copy_vec2(lua_State *l) {
+  get_buf(1, buf1, "copy vec");
+  get_buf(2, buf2, "copy vec");
+
+  buf1[0] = buf2[0]; 
+  buf1[1] = buf2[1];
+
+  return 0;
+}
+
+static int lua_length_vec2(lua_State *l) {
+  get_buf(1, buf1, "length vec2");
+  float result = p2m_vec2_length(buf1);
+  lua_pushnumber(l, result);
+  return 1;
+}
+
+static int lua_dot_vec2(lua_State *l) {
+  get_buf(1, buf1, "dot vec2");
+  get_buf(2, buf2, "dot vec2");
+  float dot = p2m_vec2_dot(buf1, buf2);
+  lua_pushnumber(l, dot);
+  return 1;
+}
+
+static int lua_rotate_vec2(lua_State *l) {
+  get_buf(1, v, "rotate vec2");
+  float angle = lua_tonumber(l, 2);
+  p2m_vec2_rotate(v, angle);
+  return 0;
+}
+
+static int lua_scale_vec2(lua_State *l) {
+  get_buf(1, buf1, "scale vec2");
+  float scalar = lua_tonumber(l, 2);
+  p2m_vec2_scale(buf1, scalar);
+  return 0;
+}
+
+int vec2lua_init(lua_State *l) {
+  lua_getglobal(l, "MATH_C_LIB");
+  lua_pushcfunction(l, lua_add_vec2);
+  lua_setfield(l, -2, "addVec2");
+  lua_pushcfunction(l, lua_sub_vec2);
+  lua_setfield(l, -2, "subVec2");
+  lua_pushcfunction(l, lua_copy_vec2);
+  lua_setfield(l, -2, "copyVec2");
+  lua_pushcfunction(l, lua_length_vec2);
+  lua_setfield(l, -2, "lenVec2");
+  lua_pushcfunction(l, lua_dot_vec2);
+  lua_setfield(l, -2, "dotVec2");
+  lua_pushcfunction(l, lua_rotate_vec2);
+  lua_setfield(l, -2, "rotateVec2");
+  lua_pushcfunction(l, lua_scale_vec2);
+  lua_setfield(l, -2, "scaleVec2");
+  lua_pop(l, 1);
+  return 0;
+}

--- a/src/math/vec3lua.c
+++ b/src/math/vec3lua.c
@@ -58,7 +58,7 @@ static int lua_length_vec3(lua_State *l) {
 
 static int lua_normalize_vec3(lua_State *l) {
   get_buf(1, buf1, "normalize vec3");
-  float len = p2m_vec2_length(buf1);
+  float len = p2m_vec3_length(buf1);
   buf1[0] /= len;
   buf1[1] /= len;
   buf1[2] /= len;

--- a/src/math/vec3lua.c
+++ b/src/math/vec3lua.c
@@ -4,7 +4,7 @@
 #include "log.h"
 
 #define buffer_null_check(p, s) \
-  do{ if(!p) { lua_pushstring(l, "got null buffer for " s); \
+  do { if (!p) { lua_pushstring(l, "got null buffer for " s); \
                 lua_error(l); return 1; } }while(0)
 
 #define get_buf(i, to, msg) \
@@ -19,7 +19,7 @@ static int lua_add_vec3(lua_State *l) {
   get_buf(1, buf1, "copy vec3");
   get_buf(2, buf2, "copy vec3");
 
-  buf1[0] += buf2[0]; 
+  buf1[0] += buf2[0];
   buf1[1] += buf2[1];
   buf1[2] += buf2[2];
 
@@ -30,7 +30,7 @@ static int lua_sub_vec3(lua_State *l) {
   get_buf(1, buf1, "sub vec3");
   get_buf(2, buf2, "sub vec3");
 
-  buf1[0] -= buf2[0]; 
+  buf1[0] -= buf2[0];
   buf1[1] -= buf2[1];
   buf1[2] -= buf2[2];
 
@@ -42,7 +42,7 @@ static int lua_copy_vec3(lua_State *l) {
   get_buf(1, buf1, "copy vec3");
   get_buf(2, buf2, "copy vec3");
 
-  buf1[0] = buf2[0]; 
+  buf1[0] = buf2[0];
   buf1[1] = buf2[1];
   buf1[2] = buf2[2];
 

--- a/src/math/vec3lua.c
+++ b/src/math/vec3lua.c
@@ -1,0 +1,90 @@
+#include <lua.h>
+
+#include "ps2math.h"
+#include "log.h"
+
+#define buffer_null_check(p, s) \
+  do{ if(!p) { lua_pushstring(l, "got null buffer for " s); \
+                lua_error(l); return 1; } }while(0)
+
+#define get_buf(i, to, msg) \
+  lua_pushstring(l, "ptr"); \
+  lua_gettable(l, i); \
+  float *to = lua_touserdata(l, -1); \
+  buffer_null_check(to, msg " [" #i "]"); \
+  ((void)0)
+
+
+static int lua_add_vec3(lua_State *l) {
+  get_buf(1, buf1, "copy vec3");
+  get_buf(2, buf2, "copy vec3");
+
+  buf1[0] += buf2[0]; 
+  buf1[1] += buf2[1];
+  buf1[2] += buf2[2];
+
+  return 0;
+}
+
+static int lua_sub_vec3(lua_State *l) {
+  get_buf(1, buf1, "sub vec3");
+  get_buf(2, buf2, "sub vec3");
+
+  buf1[0] -= buf2[0]; 
+  buf1[1] -= buf2[1];
+  buf1[2] -= buf2[2];
+
+  return 0;
+}
+
+// local c = copy(to, from)
+static int lua_copy_vec3(lua_State *l) {
+  get_buf(1, buf1, "copy vec3");
+  get_buf(2, buf2, "copy vec3");
+
+  buf1[0] = buf2[0]; 
+  buf1[1] = buf2[1];
+  buf1[2] = buf2[2];
+
+  return 0;
+}
+
+static int lua_length_vec3(lua_State *l) {
+  get_buf(1, buf1, "length vec3");
+  float result = p2m_vec3_length(buf1);
+  lua_pushnumber(l, result);
+  return 1;
+}
+
+static int lua_dot_vec3(lua_State *l) {
+  get_buf(1, buf1, "dot vec3");
+  get_buf(2, buf2, "dot vec3");
+  float dot = p2m_vec3_dot(buf1, buf2);
+  lua_pushnumber(l, dot);
+  return 1;
+}
+
+static int lua_scale_vec3(lua_State *l) {
+  get_buf(1, buf1, "scale vec3");
+  float scalar = lua_tonumber(l, 2);
+  p2m_vec3_scale(buf1, scalar);
+  return 0;
+}
+
+int vec3lua_init(lua_State *l) {
+  lua_getglobal(l, "MATH_C_LIB");
+  lua_pushcfunction(l, lua_add_vec3);
+  lua_setfield(l, -2, "addVec3");
+  lua_pushcfunction(l, lua_sub_vec3);
+  lua_setfield(l, -2, "subVec3");
+  lua_pushcfunction(l, lua_copy_vec3);
+  lua_setfield(l, -2, "copyVec3");
+  lua_pushcfunction(l, lua_length_vec3);
+  lua_setfield(l, -2, "lenVec3");
+  lua_pushcfunction(l, lua_dot_vec3);
+  lua_setfield(l, -2, "dotVec3");
+  lua_pushcfunction(l, lua_scale_vec3);
+  lua_setfield(l, -2, "scaleVec3");
+  lua_pop(l, 1);
+  return 0;
+}

--- a/src/math/vec3lua.c
+++ b/src/math/vec3lua.c
@@ -56,6 +56,15 @@ static int lua_length_vec3(lua_State *l) {
   return 1;
 }
 
+static int lua_normalize_vec3(lua_State *l) {
+  get_buf(1, buf1, "normalize vec3");
+  float len = p2m_vec2_length(buf1);
+  buf1[0] /= len;
+  buf1[1] /= len;
+  buf1[2] /= len;
+  return 0;
+}
+
 static int lua_dot_vec3(lua_State *l) {
   get_buf(1, buf1, "dot vec3");
   get_buf(2, buf2, "dot vec3");
@@ -81,6 +90,8 @@ int vec3lua_init(lua_State *l) {
   lua_setfield(l, -2, "copyVec3");
   lua_pushcfunction(l, lua_length_vec3);
   lua_setfield(l, -2, "lenVec3");
+  lua_pushcfunction(l, lua_normalize_vec3);
+  lua_setfield(l, -2, "normalizeVec3");
   lua_pushcfunction(l, lua_dot_vec3);
   lua_setfield(l, -2, "dotVec3");
   lua_pushcfunction(l, lua_scale_vec3);

--- a/src/ps2math.c
+++ b/src/ps2math.c
@@ -1,7 +1,7 @@
 #include <math.h>
 
-#include "ps2math.h"
 #include "log.h"
+#include "ps2math.h"
 
 float p2m_vec2_length(float *v2) {
   float xs = v2[0] * v2[0];
@@ -9,15 +9,13 @@ float p2m_vec2_length(float *v2) {
   return sqrtf(xs + ys);
 }
 
-float p2m_vec2_dot(float *a, float *b) {
-  return (a[0]*b[0]) + (a[1]*b[1]); 
-}
+float p2m_vec2_dot(float *a, float *b) { return (a[0] * b[0]) + (a[1] * b[1]); }
 
 void p2m_vec2_rotate(float *v, float theta) {
   float x = v[0];
   float y = v[1];
-  v[0] = x*cosf(theta) - y*sinf(theta);
-  v[1] = x*sinf(theta) + y*cosf(theta);
+  v[0] = x * cosf(theta) - y * sinf(theta);
+  v[1] = x * sinf(theta) + y * cosf(theta);
 }
 
 void p2m_vec2_scale(float *v, float s) {
@@ -33,40 +31,46 @@ float p2m_vec3_length(float *v3) {
 }
 
 float p2m_vec3_dot(float *a, float *b) {
-  return (a[0]*b[0]) + (a[1]*b[1]) + (a[2]*b[2]); 
+  return (a[0] * b[0]) + (a[1] * b[1]) + (a[2] * b[2]);
 }
 
 void p2m_vec3_scale(float *v, float s) {
-  v[0] *= s; 
-  v[1] *= s; 
-  v[2] *= s; 
+  v[0] *= s;
+  v[1] *= s;
+  v[2] *= s;
 }
 
 void p2m_m3_copy(float *a, float *b) {
-  for(int i = 0; i < 9; i++) {
+  for (int i = 0; i < 9; i++) {
     a[i] = b[i];
   }
 }
 
 void p2m_m3_apply(float *m3, float *v) {
-  float nx = m3[0]*v[0] + m3[1]*v[1] + m3[2]*v[2];
-  float ny = m3[3]*v[0] + m3[4]*v[1] + m3[5]*v[2];
-  float nz = m3[6]*v[0] + m3[7]*v[1] + m3[8]*v[2];
+  float nx = m3[0] * v[0] + m3[1] * v[1] + m3[2] * v[2];
+  float ny = m3[3] * v[0] + m3[4] * v[1] + m3[5] * v[2];
+  float nz = m3[6] * v[0] + m3[7] * v[1] + m3[8] * v[2];
   v[0] = nx;
   v[1] = ny;
   v[2] = nz;
 }
 
 void p2m_m3_add(float *a, float *b) {
-  for(int i = 0; i < 9; i++) {
+  for (int i = 0; i < 9; i++) {
     a[i] += b[i];
   }
 }
 
 void p2m_m3_identity(float *m) {
-  m[0] = 1; m[1] = 0; m[2] = 0;
-  m[3] = 0; m[4] = 1; m[5] = 0;
-  m[6] = 0; m[7] = 0; m[8] = 1;
+  m[0] = 1;
+  m[1] = 0;
+  m[2] = 0;
+  m[3] = 0;
+  m[4] = 1;
+  m[5] = 0;
+  m[6] = 0;
+  m[7] = 0;
+  m[8] = 1;
 }
 
 void p2m_m3_multiply(float *a, float *b, float *to) {
@@ -99,5 +103,3 @@ void p2m_m3_multiply(float *a, float *b, float *to) {
   to[5] = a01 * b20 + a11 * b21 + a21 * b22;
   to[8] = a02 * b20 + a12 * b21 + a22 * b22;
 }
-
-

--- a/src/ps2math.c
+++ b/src/ps2math.c
@@ -1,0 +1,103 @@
+#include <math.h>
+
+#include "ps2math.h"
+#include "log.h"
+
+float p2m_vec2_length(float *v2) {
+  float xs = v2[0] * v2[0];
+  float ys = v2[1] * v2[1];
+  return sqrtf(xs + ys);
+}
+
+float p2m_vec2_dot(float *a, float *b) {
+  return (a[0]*b[0]) + (a[1]*b[1]); 
+}
+
+void p2m_vec2_rotate(float *v, float theta) {
+  float x = v[0];
+  float y = v[1];
+  v[0] = x*cosf(theta) - y*sinf(theta);
+  v[1] = x*sinf(theta) + y*cosf(theta);
+}
+
+void p2m_vec2_scale(float *v, float s) {
+  v[0] *= s;
+  v[1] *= s;
+}
+
+float p2m_vec3_length(float *v3) {
+  float xs = v3[0] * v3[0];
+  float ys = v3[1] * v3[1];
+  float zs = v3[2] * v3[2];
+  return sqrtf(xs + ys + zs);
+}
+
+float p2m_vec3_dot(float *a, float *b) {
+  return (a[0]*b[0]) + (a[1]*b[1]) + (a[2]*b[2]); 
+}
+
+void p2m_vec3_scale(float *v, float s) {
+  v[0] *= s; 
+  v[1] *= s; 
+  v[2] *= s; 
+}
+
+void p2m_m3_copy(float *a, float *b) {
+  for(int i = 0; i < 9; i++) {
+    a[i] = b[i];
+  }
+}
+
+void p2m_m3_apply(float *m3, float *v) {
+  float nx = m3[0]*v[0] + m3[1]*v[1] + m3[2]*v[2];
+  float ny = m3[3]*v[0] + m3[4]*v[1] + m3[5]*v[2];
+  float nz = m3[6]*v[0] + m3[7]*v[1] + m3[8]*v[2];
+  v[0] = nx;
+  v[1] = ny;
+  v[2] = nz;
+}
+
+void p2m_m3_add(float *a, float *b) {
+  for(int i = 0; i < 9; i++) {
+    a[i] += b[i];
+  }
+}
+
+void p2m_m3_identity(float *m) {
+  m[0] = 1; m[1] = 0; m[2] = 0;
+  m[3] = 0; m[4] = 1; m[5] = 0;
+  m[6] = 0; m[7] = 0; m[8] = 1;
+}
+
+void p2m_m3_multiply(float *a, float *b, float *to) {
+  float a00 = a[0];
+  float a10 = a[1];
+  float a20 = a[2];
+  float a01 = a[3];
+  float a11 = a[4];
+  float a21 = a[5];
+  float a02 = a[6];
+  float a12 = a[7];
+  float a22 = a[8];
+  float b00 = b[0];
+  float b10 = b[1];
+  float b20 = b[2];
+  float b01 = b[3];
+  float b11 = b[4];
+  float b21 = b[5];
+  float b02 = b[6];
+  float b12 = b[7];
+  float b22 = b[8];
+
+  to[0] = a00 * b00 + a10 * b01 + a20 * b02;
+  to[3] = a01 * b00 + a11 * b01 + a21 * b02;
+  to[6] = a02 * b00 + a12 * b01 + a22 * b02;
+  to[1] = a00 * b10 + a10 * b11 + a20 * b12;
+  to[4] = a01 * b10 + a11 * b11 + a21 * b12;
+  to[7] = a02 * b10 + a12 * b11 + a22 * b12;
+  to[2] = a00 * b20 + a10 * b21 + a20 * b22;
+  to[5] = a01 * b20 + a11 * b21 + a21 * b22;
+  to[8] = a02 * b20 + a12 * b21 + a22 * b22;
+}
+
+

--- a/src/ps2math.h
+++ b/src/ps2math.h
@@ -1,0 +1,21 @@
+
+#ifndef PS2_MATH_H
+#define PS2_MATH_H
+
+float p2m_vec2_length(float *v2);
+float p2m_vec2_dot(float *a, float *b);
+void  p2m_vec2_rotate(float *v2, float theta);
+void p2m_vec2_scale(float *v, float s);
+
+float p2m_vec3_length(float *v3);
+float p2m_vec3_dot(float *a, float *b);
+void p2m_vec3_scale(float *v, float s);
+
+void p2m_m3_copy(float *a, float *b);
+void p2m_m3_apply(float *m3, float *v);
+void p2m_m3_add(float *a, float *b);
+void p2m_m3_identity(float *m);
+void p2m_m3_multiply(float *a, float *b, float *to);
+
+
+#endif

--- a/src/ps2math.h
+++ b/src/ps2math.h
@@ -4,7 +4,7 @@
 
 float p2m_vec2_length(float *v2);
 float p2m_vec2_dot(float *a, float *b);
-void  p2m_vec2_rotate(float *v2, float theta);
+void p2m_vec2_rotate(float *v2, float theta);
 void p2m_vec2_scale(float *v, float s);
 
 float p2m_vec3_length(float *v3);
@@ -16,6 +16,5 @@ void p2m_m3_apply(float *m3, float *v);
 void p2m_m3_add(float *a, float *b);
 void p2m_m3_identity(float *m);
 void p2m_m3_multiply(float *a, float *b, float *to);
-
 
 #endif

--- a/src/script.h
+++ b/src/script.h
@@ -15,5 +15,6 @@ int draw2d_lua_init(lua_State *l);
 int vec2lua_init(lua_State *l);
 int vec3lua_init(lua_State *l);
 int mat3lua_init(lua_State *l);
+int floatmath_init(lua_State *l);
 
 #endif

--- a/src/script.h
+++ b/src/script.h
@@ -11,4 +11,9 @@ int loglua_init(lua_State *l);
 int lua_tga_init(lua_State *l);
 int draw2d_lua_init(lua_State *l);
 
+// math...
+int vec2lua_init(lua_State *l);
+int vec3lua_init(lua_State *l);
+int mat3lua_init(lua_State *l);
+
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 
-#include "utils.h"
 #include "log.h"
+#include "utils.h"
 
 /**
  * print a QWORD buffer as trace level log


### PR DESCRIPTION
Math systems work as follows:
- Vector/Matrices are backed by boring C arrays
- Lua wraps these in an object compatible with "ps2.buffer" metatable
- Matrix/Vector operations are defined in C in terms of C arrays
- Lua bindings are wrapped in pure Lua utility functions which pass the underlying Lua ps2.buffer to C functions for manipulation
- Operations override the LHS parameter, eg `A:add(B)` mutates A. To achieve `A = B + C` we first make A a copy of B, then evaluate `A:add(C)`

We can create pipelines of math operations in Lua, but then trivially port those to C later if performance is a problem.

Missing/Todo:
- [x] Cleanup eg/math.lua tests
- [x] Fix tostring()